### PR TITLE
Standalone CLI

### DIFF
--- a/ConverterApp/ExportItemSelection.cs
+++ b/ConverterApp/ExportItemSelection.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 using LSLib.Granny.Model;
 using LSLib.Granny.Model.CurveData;

--- a/ConverterApp/GR2Pane.cs
+++ b/ConverterApp/GR2Pane.cs
@@ -1,12 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using LSLib.Granny;
 using LSLib.Granny.GR2;

--- a/ConverterApp/GR2Pane.cs
+++ b/ConverterApp/GR2Pane.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using LSLib.Granny;
 using LSLib.Granny.GR2;
 using LSLib.Granny.Model;
+using LSLib.LS.Enums;
 
 namespace ConverterApp
 {
@@ -176,7 +177,7 @@ namespace ConverterApp
         private void UpdateCommonExporterSettings(ExporterOptions settings)
         {
             var game = Form.GetGame();
-            if (game == DivGame.DOS)
+            if (game == Game.DivinityOriginalSin)
             {
                 settings.Is64Bit = false;
                 settings.AlternateSignature = false;

--- a/ConverterApp/MainForm.cs
+++ b/ConverterApp/MainForm.cs
@@ -1,16 +1,10 @@
 ﻿using LSLib.LS;
 using System;
 using System.Windows.Forms;
+using LSLib.LS.Enums;
 
 namespace ConverterApp
 {
-    public enum DivGame
-    {
-        DOS = 0,
-        DOSEE = 1,
-        DOS2 = 2
-    };
-
     public partial class MainForm : Form
     {
         public MainForm()
@@ -41,22 +35,22 @@ namespace ConverterApp
             gr2Game.SelectedIndex = 1;
         }
 
-        public DivGame GetGame()
+        public Game GetGame()
         {
             switch (gr2Game.SelectedIndex)
             {
-                case 0: return DivGame.DOS;
-                case 1: return DivGame.DOSEE;
-                case 2: return DivGame.DOS2;
+                case 0: return Game.DivinityOriginalSin;
+                case 1: return Game.DivinityOriginalSinEE;
+                case 2: return Game.DivinityOriginalSin2;
                 default: throw new InvalidOperationException();
             }
         }
 
         private void gr2Game_SelectedIndexChanged(object sender, EventArgs e)
         {
-            DivGame game = GetGame();
+            Game game = GetGame();
             var pane = this.gr2Tab.Controls[0] as GR2Pane;
-            pane.use16bitIndex.Checked = game == DivGame.DOSEE || game == DivGame.DOS2;
+            pane.use16bitIndex.Checked = game == Game.DivinityOriginalSinEE || game == Game.DivinityOriginalSin2;
         }
     }
 }

--- a/ConverterApp/MainForm.cs
+++ b/ConverterApp/MainForm.cs
@@ -1,12 +1,5 @@
 ﻿using LSLib.LS;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace ConverterApp

--- a/ConverterApp/OsirisPane.cs
+++ b/ConverterApp/OsirisPane.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using LSLib.LS;
 using LSLib.LS.Osiris;
 using System.IO;
+using LSLib.LS.Enums;
 using LSLib.LS.LSF;
 
 namespace ConverterApp

--- a/ConverterApp/PackagePane.cs
+++ b/ConverterApp/PackagePane.cs
@@ -1,14 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using LSLib.LS;
 using System.Diagnostics;
+using LSLib.LS.Enums;
 
 namespace ConverterApp
 {

--- a/ConverterApp/Program.cs
+++ b/ConverterApp/Program.cs
@@ -1,8 +1,4 @@
-﻿using LSLib.LS;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System;
 using System.Windows.Forms;
 
 namespace ConverterApp

--- a/ConverterApp/ResourcePane.cs
+++ b/ConverterApp/ResourcePane.cs
@@ -24,15 +24,7 @@ namespace ConverterApp
             {
                 Resource = ResourceUtils.LoadResource(resourceInputPath.Text);
                 var format = ResourceUtils.ExtensionToResourceFormat(resourceOutputPath.Text);
-                int outputVersion = -1;
-                if (Form.GetGame() == DivGame.DOS2)
-                {
-                    outputVersion = (int)FileVersion.VerExtendedNodes;
-                }
-                else
-                {
-                    outputVersion = (int)FileVersion.VerChunkedCompress;
-                }
+                FileVersion outputVersion = Form.GetGame() == DivGame.DOS2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                 ResourceUtils.SaveResource(Resource, resourceOutputPath.Text, format, outputVersion);
                 MessageBox.Show("Resource saved successfully.");
             }
@@ -116,7 +108,7 @@ namespace ConverterApp
             }
 
             ResourceFormat outputFormat = ResourceFormat.LSF;
-            int outputVersion = -1;
+            FileVersion outputVersion = 0x0;
             switch (resourceOutputFormatCb.SelectedIndex)
             {
                 case 0:
@@ -129,14 +121,7 @@ namespace ConverterApp
 
                 case 2:
                     outputFormat = ResourceFormat.LSF;
-                    if (Form.GetGame() == DivGame.DOS2)
-                    {
-                        outputVersion = (int)FileVersion.VerExtendedNodes;
-                    }
-                    else
-                    {
-                        outputVersion = (int)FileVersion.VerChunkedCompress;
-                    }
+                    outputVersion = Form.GetGame() == DivGame.DOS2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                     break;
 
                 case 3:

--- a/ConverterApp/ResourcePane.cs
+++ b/ConverterApp/ResourcePane.cs
@@ -24,7 +24,7 @@ namespace ConverterApp
             {
                 Resource = ResourceUtils.LoadResource(resourceInputPath.Text);
                 var format = ResourceUtils.ExtensionToResourceFormat(resourceOutputPath.Text);
-                FileVersion outputVersion = Form.GetGame() == DivGame.DOS2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+                FileVersion outputVersion = Form.GetGame() == Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                 ResourceUtils.SaveResource(Resource, resourceOutputPath.Text, format, outputVersion);
                 MessageBox.Show("Resource saved successfully.");
             }
@@ -121,7 +121,7 @@ namespace ConverterApp
 
                 case 2:
                     outputFormat = ResourceFormat.LSF;
-                    outputVersion = Form.GetGame() == DivGame.DOS2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+                    outputVersion = Form.GetGame() == Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                     break;
 
                 case 3:

--- a/ConverterApp/ResourcePane.cs
+++ b/ConverterApp/ResourcePane.cs
@@ -1,14 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using LSLib.LS;
-using LSLib.LS.LSF;
+using LSLib.LS.Enums;
 
 namespace ConverterApp
 {

--- a/Divine/App.config
+++ b/Divine/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    </startup>
+</configuration>

--- a/Divine/App.config
+++ b/Divine/App.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+  </startup>
 </configuration>

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Divine.Enums;
-using LSLib.LS;
+using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
@@ -18,7 +18,7 @@ namespace Divine.CLI
         public static ResourceFormat InputFormat;
         public static ResourceFormat OutputFormat;
         public static PackageVersion PackageVersion;
-        public static Dictionary<string, bool> GraphicsOptions;
+        public static Dictionary<string, bool> GR2Options;
 
         // TODO: OSI support
 
@@ -46,7 +46,7 @@ namespace Divine.CLI
                 {
                     if (args.InputFormat == null && args.Action != "extract-packages")
                     {
-                        CommandLineLogger.LogFatal("Cannot perform batch action without --input-format and --output-format arguments");
+                        CommandLineLogger.LogFatal("Cannot perform batch action without --input-format and --output-format arguments", 1);
                     }
                 }
 
@@ -68,10 +68,10 @@ namespace Divine.CLI
 
             if (graphicsActions.Any(args.Action.Contains))
             {
-                GraphicsOptions = CommandLineArguments.GetGraphicsOptions(args.Options);
-                CommandLineLogger.LogDebug($"Using graphics options: {GraphicsOptions}");
+                GR2Options = CommandLineArguments.GetGR2Options(args.Options);
+                CommandLineLogger.LogDebug($"Using graphics options: {GR2Options}");
 
-                if (GraphicsOptions["conform"])
+                if (GR2Options["conform"])
                 {
                     ConformPath = TryToValidatePath(args.ConformPath);
                 }
@@ -92,8 +92,8 @@ namespace Divine.CLI
                     CommandLinePackageProcessor.Extract();
                     break;
                 case "convert-model":
-                    CommandLineGraphicsProcessor.UpdateExporterSettings();
-                    CommandLineGraphicsProcessor.Convert();
+                    CommandLineGR2Processor.UpdateExporterSettings();
+                    CommandLineGR2Processor.Convert();
                     break;
                 case "convert-resource":
                     CommandLineDataProcessor.Convert();
@@ -102,7 +102,7 @@ namespace Divine.CLI
                     CommandLinePackageProcessor.BatchExtract();
                     break;
                 case "convert-models":
-                    CommandLineGraphicsProcessor.BatchConvert();
+                    CommandLineGR2Processor.BatchConvert();
                     break;
                 case "convert-resources":
                     CommandLineDataProcessor.BatchConvert();
@@ -118,7 +118,7 @@ namespace Divine.CLI
 
             if (string.IsNullOrWhiteSpace(path))
             {
-                CommandLineLogger.LogFatal($"Cannot parse path from input: {path}");
+                CommandLineLogger.LogFatal($"Cannot parse path from input: {path}", 1);
             }
 
             Uri uri = null;
@@ -128,12 +128,12 @@ namespace Divine.CLI
             }
             catch (InvalidOperationException)
             {
-                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E1]: {path}");
+                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E1]: {path}", 1);
             }
 
             if (uri != null && (!Path.IsPathRooted(path) || !uri.IsFile))
             {
-                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E2]: {path}");
+                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E2]: {path}", 1);
             }
 
             // ReSharper disable once AssignNullToNotNullAttribute
@@ -141,7 +141,7 @@ namespace Divine.CLI
 
             if (path.Length > MAX_PATH)
             {
-                CommandLineLogger.LogFatal($"Cannot proceed with path exceeding {MAX_PATH} characters: {path}");
+                CommandLineLogger.LogFatal($"Cannot proceed with path exceeding {MAX_PATH} characters: {path}", 1);
             }
 
             return path;

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -30,16 +30,32 @@ namespace Divine.CLI
 
         private static void SetUpAndValidate(CommandLineArguments args)
         {
-            string[] batchActions = { "extract-packages", "convert-models", "convert-resources" };
-            string[] packageActions = { "create-package", "extract-package", "extract-packages" };
-            string[] graphicsActions = { "convert-model", "convert-models" };
+            string[] batchActions =
+            {
+                "extract-packages",
+                "convert-models",
+                "convert-resources"
+            };
+
+            string[] packageActions =
+            {
+                "create-package",
+                "extract-package",
+                "extract-packages"
+            };
+
+            string[] graphicsActions =
+            {
+                "convert-model",
+                "convert-models"
+            };
 
             LogLevel = CommandLineArguments.GetLogLevelByString(args.LogLevel);
             CommandLineLogger.LogDebug($"Using log level: {LogLevel}");
 
             Game = CommandLineArguments.GetGameByString(args.Game);
             CommandLineLogger.LogDebug($"Using game: {Game}");
-            
+
             if (batchActions.Any(args.Action.Contains))
             {
                 if (args.InputFormat == null || args.OutputFormat == null)

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -35,7 +35,7 @@ namespace Divine.CLI
             string[] graphicsActions = { "convert-model", "convert-models" };
 
             LogLevel = CommandLineArguments.GetLogLevelByString(args.LogLevel);
-            CommandLineLogger.LogInfo($"Using log level: {LogLevel}");
+            CommandLineLogger.LogDebug($"Using log level: {LogLevel}");
 
             Game = CommandLineArguments.GetGameByString(args.Game);
             CommandLineLogger.LogDebug($"Using game: {Game}");

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -104,22 +104,28 @@ namespace Divine.CLI
                 case "create-package":
                     CommandLinePackageProcessor.Create();
                     break;
+
                 case "extract-package":
                     CommandLinePackageProcessor.Extract();
                     break;
+
                 case "convert-model":
                     CommandLineGR2Processor.UpdateExporterSettings();
                     CommandLineGR2Processor.Convert();
                     break;
+
                 case "convert-resource":
                     CommandLineDataProcessor.Convert();
                     break;
+
                 case "extract-packages":
                     CommandLinePackageProcessor.BatchExtract();
                     break;
+
                 case "convert-models":
                     CommandLineGR2Processor.BatchConvert();
                     break;
+
                 case "convert-resources":
                     CommandLineDataProcessor.BatchConvert();
                     break;
@@ -128,7 +134,7 @@ namespace Divine.CLI
 
         public static string TryToValidatePath(string path)
         {
-            const int MAX_PATH = 248;
+            const int maxPath = 248;
 
             CommandLineLogger.LogDebug($"Using path: {path}");
 
@@ -155,9 +161,9 @@ namespace Divine.CLI
             // ReSharper disable once AssignNullToNotNullAttribute
             path = Path.GetFullPath(path);
 
-            if (path.Length > MAX_PATH)
+            if (path.Length > maxPath)
             {
-                CommandLineLogger.LogFatal($"Cannot proceed with path exceeding {MAX_PATH} characters: {path}", 1);
+                CommandLineLogger.LogFatal($"Cannot proceed with path exceeding {maxPath} characters: {path}", 1);
             }
 
             return path;

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Divine.Enums;
+using LSLib.LS;
+
+namespace Divine.CLI
+{
+    internal class CommandLineActions
+    {
+        public static string SourcePath;
+        public static string DestinationPath;
+        public static string ConformPath;
+
+        public static Game Game;
+        public static LogLevel LogLevel;
+        public static ResourceFormat InputFormat;
+        public static ResourceFormat OutputFormat;
+        public static PackageVersion PackageVersion;
+        public static Dictionary<string, bool> GraphicsOptions;
+
+        // TODO: OSI support
+
+        public static void Run(CommandLineArguments args)
+        {
+            SetUpAndValidate(args);
+            Process(args);
+        }
+
+        private static void SetUpAndValidate(CommandLineArguments args)
+        {
+            string[] batchActions = { "extract-packages", "convert-models", "convert-resources" };
+            string[] packageActions = { "create-package", "extract-package", "extract-packages" };
+            string[] graphicsActions = { "convert-model", "convert-models" };
+
+            LogLevel = CommandLineArguments.GetLogLevelByString(args.LogLevel);
+            CommandLineLogger.LogInfo($"Using log level: {LogLevel}");
+
+            Game = CommandLineArguments.GetGameByString(args.Game);
+            CommandLineLogger.LogDebug($"Using game: {Game}");
+            
+            if (batchActions.Any(args.Action.Contains))
+            {
+                if (args.InputFormat == null || args.OutputFormat == null)
+                {
+                    if (args.InputFormat == null && args.Action != "extract-packages")
+                    {
+                        CommandLineLogger.LogFatal("Cannot perform batch action without --input-format and --output-format arguments");
+                    }
+                }
+
+                InputFormat = CommandLineArguments.GetResourceFormatByString(args.InputFormat);
+                CommandLineLogger.LogDebug($"Using input format: {InputFormat}");
+
+                if (args.Action != "extract-packages")
+                {
+                    OutputFormat = CommandLineArguments.GetResourceFormatByString(args.OutputFormat);
+                    CommandLineLogger.LogDebug($"Using output format: {OutputFormat}");
+                }
+            }
+
+            if (packageActions.Any(args.Action.Contains))
+            {
+                PackageVersion = CommandLineArguments.GetPackageVersion(args.PackageVersion);
+                CommandLineLogger.LogDebug($"Using package version: {PackageVersion}");
+            }
+
+            if (graphicsActions.Any(args.Action.Contains))
+            {
+                GraphicsOptions = CommandLineArguments.GetGraphicsOptions(args.Options);
+                CommandLineLogger.LogDebug($"Using graphics options: {GraphicsOptions}");
+
+                if (GraphicsOptions["conform"])
+                {
+                    ConformPath = TryToValidatePath(args.ConformPath);
+                }
+            }
+
+            SourcePath = TryToValidatePath(args.Source);
+            DestinationPath = TryToValidatePath(args.Destination);
+        }
+
+        private static void Process(CommandLineArguments args)
+        {
+            switch (args.Action)
+            {
+                case "create-package":
+                    CommandLinePackageProcessor.Create();
+                    break;
+                case "extract-package":
+                    CommandLinePackageProcessor.Extract();
+                    break;
+                case "convert-model":
+                    CommandLineGraphicsProcessor.UpdateExporterSettings();
+                    CommandLineGraphicsProcessor.Convert();
+                    break;
+                case "convert-resource":
+                    CommandLineDataProcessor.Convert();
+                    break;
+                case "extract-packages":
+                    CommandLinePackageProcessor.BatchExtract();
+                    break;
+                case "convert-models":
+                    CommandLineGraphicsProcessor.BatchConvert();
+                    break;
+                case "convert-resources":
+                    CommandLineDataProcessor.BatchConvert();
+                    break;
+            }
+        }
+
+        public static string TryToValidatePath(string path)
+        {
+            const int MAX_PATH = 248;
+
+            CommandLineLogger.LogDebug($"Using path: {path}");
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                CommandLineLogger.LogFatal($"Cannot parse path from input: {path}");
+            }
+
+            Uri uri = null;
+            try
+            {
+                Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out uri);
+            }
+            catch (InvalidOperationException)
+            {
+                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E1]: {path}");
+            }
+
+            if (uri != null && (!Path.IsPathRooted(path) || !uri.IsFile))
+            {
+                CommandLineLogger.LogFatal($"Cannot proceed without absolute path [E2]: {path}");
+            }
+
+            // ReSharper disable once AssignNullToNotNullAttribute
+            path = Path.GetFullPath(path);
+
+            if (path.Length > MAX_PATH)
+            {
+                CommandLineLogger.LogFatal($"Cannot proceed with path exceeding {MAX_PATH} characters: {path}");
+            }
+
+            return path;
+        }
+    }
+}

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -71,7 +71,7 @@ namespace Divine.CLI
         [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
             Description = "Set verbosity level of log output",
             DefaultValue = "info",
-            AllowedValues = "info;warn;error;fatal;debug;silent",
+            AllowedValues = "off;fatal;error;warn;info;debug;trace;all",
             ValueOptional = false,
             Optional = true
         )]
@@ -118,137 +118,76 @@ namespace Divine.CLI
 
         // @formatter:on
 
-        public static LogLevel GetLogLevelByString(string optionLogLevel)
+        public static LogLevel GetLogLevelByString(string logLevel)
         {
-            LogLevel logLevel;
-
-            switch (optionLogLevel)
+            switch (logLevel)
             {
-                case "off":
-                    logLevel = Enums.LogLevel.OFF;
-                    break;
-                case "fatal":
-                    logLevel = Enums.LogLevel.FATAL;
-                    break;
-                case "error":
-                    logLevel = Enums.LogLevel.ERROR;
-                    break;
-                case "warn":
-                    logLevel = Enums.LogLevel.WARN;
-                    break;
-                case "info":
-                    logLevel = Enums.LogLevel.INFO;
-                    break;
-                case "debug":
-                    logLevel = Enums.LogLevel.DEBUG;
-                    break;
-                case "trace":
-                    logLevel = Enums.LogLevel.TRACE;
-                    break;
-                case "all":
-                    logLevel = Enums.LogLevel.ALL;
-                    break;
-                default:
-                    logLevel = Enums.LogLevel.INFO;
-                    break;
+                case "off": return Enums.LogLevel.OFF;
+                case "fatal": return Enums.LogLevel.FATAL;
+                case "error": return Enums.LogLevel.ERROR;
+                case "warn": return Enums.LogLevel.WARN;
+                case "info": return Enums.LogLevel.INFO;
+                case "debug": return Enums.LogLevel.DEBUG;
+                case "trace": return Enums.LogLevel.TRACE;
+                case "all": return Enums.LogLevel.ALL;
+                default: return Enums.LogLevel.INFO;
             }
-
-            return logLevel;
         }
 
-        public static Game GetGameByString(string optionGame)
+        // ReSharper disable once RedundantCaseLabel
+        public static Game GetGameByString(string game)
         {
-            Game game;
-
-            switch (optionGame)
+            switch (game)
             {
-                case "dos":
-                    game = LSLib.LS.Enums.Game.DivinityOriginalSin;
-                    break;
-                case "dosee":
-                    game = LSLib.LS.Enums.Game.DivinityOriginalSinEE;
-                    break;
-//                case "dos2":
-//                    game = LSLib.LS.Enums.Game.DivinityOriginalSin2;
-//                    break;
+                case "dos": return LSLib.LS.Enums.Game.DivinityOriginalSin;
+                case "dosee": return LSLib.LS.Enums.Game.DivinityOriginalSinEE;
+                case "dos2":
                 default:
-                    game = LSLib.LS.Enums.Game.DivinityOriginalSin2;
-                    break;
+                    return LSLib.LS.Enums.Game.DivinityOriginalSin2;
             }
-
-            return game;
         }
 
         public static FileVersion GetFileVersionByGame(Game divinityGame) => divinityGame == LSLib.LS.Enums.Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
 
         public static ExportFormat GetExportFormatByString(string optionExportFormat) => optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
 
-        public static ResourceFormat GetResourceFormatByString(string optionResourceFormat)
+        // ReSharper disable once RedundantCaseLabel
+        public static ResourceFormat GetResourceFormatByString(string resourceFormat)
         {
-            ResourceFormat resourceFormat;
-
-            switch (optionResourceFormat)
+            switch (resourceFormat)
             {
-                case "lsb":
-                    resourceFormat = ResourceFormat.LSB;
-                    break;
-                case "lsf":
-                    resourceFormat = ResourceFormat.LSF;
-                    break;
-                case "lsj":
-                    resourceFormat = ResourceFormat.LSJ;
-                    break;
+                case "lsb": return ResourceFormat.LSB;
+                case "lsf": return ResourceFormat.LSF;
+                case "lsj": return ResourceFormat.LSJ;
                 case "lsx":
-                    resourceFormat = ResourceFormat.LSX;
-                    break;
                 default:
-                    resourceFormat = ResourceFormat.LSX;
-                    break;
+                    return ResourceFormat.LSX;
             }
-
-            return resourceFormat;
         }
 
-        public static PackageVersion GetPackageVersion(string versionOption)
+        // ReSharper disable once RedundantCaseLabel
+        public static PackageVersion GetPackageVersion(string packageVersion)
         {
-            PackageVersion version;
-
-            switch (versionOption)
+            switch (packageVersion)
             {
-                case "v7":
-                    version = Enums.PackageVersion.V7;
-                    break;
-
-                case "v9":
-                    version = Enums.PackageVersion.V9;
-                    break;
-
-                case "v10":
-                    version = Enums.PackageVersion.V10;
-                    break;
-
+                case "v7": return Enums.PackageVersion.V7;
+                case "v9": return Enums.PackageVersion.V9;
+                case "v10": return Enums.PackageVersion.V10;
                 case "v13":
-                    version = Enums.PackageVersion.V13;
-                    break;
-
                 default:
-                    version = Enums.PackageVersion.V13;
-                    break;
+                    return Enums.PackageVersion.V13;
             }
-
-            return version;
         }
 
-        public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion version)
+        public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion packageVersion)
         {
             CompressionMethod compression;
-            bool fastCompression;
+            var fastCompression = true;
 
             switch (compressionOption)
             {
                 case "zlibfast":
                     compression = LSLib.LS.Enums.CompressionMethod.Zlib;
-                    fastCompression = true;
                     break;
 
                 case "zlib":
@@ -258,7 +197,6 @@ namespace Divine.CLI
 
                 case "lz4":
                     compression = LSLib.LS.Enums.CompressionMethod.LZ4;
-                    fastCompression = true;
                     break;
 
                 case "lz4hc":
@@ -266,20 +204,21 @@ namespace Divine.CLI
                     fastCompression = false;
                     break;
 
+                // ReSharper disable once RedundantCaseLabel
+                case "none":
                 default:
                     compression = LSLib.LS.Enums.CompressionMethod.None;
-                    fastCompression = false;
                     break;
             }
 
             // fallback to zlib, if the package version doesn't support lz4
-            if (compression == LSLib.LS.Enums.CompressionMethod.LZ4 && version <= (PackageVersion) 9)
+            if (compression == LSLib.LS.Enums.CompressionMethod.LZ4 && packageVersion <= Enums.PackageVersion.V9)
             {
                 compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                 fastCompression = false;
             }
 
-            Dictionary<string, object> compressionOptions = new Dictionary<string, object>
+            var compressionOptions = new Dictionary<string, object>
             {
                 { "Compression", compression },
                 { "FastCompression", fastCompression }
@@ -290,7 +229,7 @@ namespace Divine.CLI
 
         public static Dictionary<string, bool> GetGR2Options(string[] options)
         {
-            Dictionary<string, bool> results = new Dictionary<string, bool>
+            var results = new Dictionary<string, bool>
             {
                 { "export-normals", false },
                 { "export-tangents", false },
@@ -313,12 +252,9 @@ namespace Divine.CLI
                 return results;
             }
 
-            foreach (string option in options)
+            foreach (string option in options.Where(option => results.Keys.Contains(option)))
             {
-                if (results.Keys.Contains(option))
-                {
-                    results[option] = true;
-                }
+                results[option] = true;
             }
 
             return results;

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -1,0 +1,310 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CommandLineParser.Arguments;
+using Divine.Enums;
+using LSLib.Granny.Model;
+using LSLib.LS;
+
+namespace Divine.CLI
+{
+    public class CommandLineArguments
+    {
+        [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
+            Description = "Set verbosity level of log output",
+            DefaultValue = "info",
+            AllowedValues = "info;warn;error;fatal;debug;silent",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string LogLevel;
+
+        [EnumeratedValueArgument(typeof(string), 'g', "game",
+            Description = "Set target game when generating output",
+            DefaultValue = "dos2",
+            AllowedValues = "dos;dosee;dos2",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string Game;
+
+        [EnumeratedValueArgument(typeof(string), 'a', "action",
+            Description = "Set action to execute",
+            DefaultValue = "extract-package",
+            AllowedValues = "create-package;extract-package;extract-packages;convert-model;convert-models;convert-resource;convert-resources",
+            ValueOptional = false,
+            Optional = false
+        )]
+        public string Action;
+
+        [ValueArgument(typeof(string), 's', "source",
+            Description = "Set source file path or directory",
+            DefaultValue = null,
+            ValueOptional = false,
+            Optional = false
+        )]
+        public string Source;
+
+        [ValueArgument(typeof(string), 'd', "destination",
+            Description = "Set destination file path or directory",
+            DefaultValue = null,
+            ValueOptional = false,
+            Optional = false
+        )]
+        public string Destination;
+
+        [EnumeratedValueArgument(typeof(string), 'i', "input-format",
+            Description = "Set input format for batch operations",
+            DefaultValue = null,
+            AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string InputFormat;
+
+        [EnumeratedValueArgument(typeof(string), 'o', "output-format",
+            Description = "Set output format for batch operations",
+            DefaultValue = null,
+            AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string OutputFormat;
+
+        [EnumeratedValueArgument(typeof(string), "gr2-options", 
+            Description = "Set extra options for GR2/DAE conversion",
+            AllowMultiple = true,
+            AllowedValues = "export-normals;export-tangents;export-uvs;deduplicate-vertices;filter-uvs;recalculate-normals;recalculate-tangents;recalculate-iwt;flip-uvs;force-legacy-version;compact-tris;build-dummy-skeleton;apply-basis-transforms;conform",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string[] Options;
+
+        [ValueArgument(typeof(string), "conform-path", 
+            Description = "Set conform to original path", 
+            DefaultValue = null,
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string ConformPath;
+
+        [EnumeratedValueArgument(typeof(string), 'p', "package-version",
+            Description = "Set package version",
+            DefaultValue = "v13",
+            AllowedValues = "v7;v9;v10;v13",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string PackageVersion;
+
+        [EnumeratedValueArgument(typeof(string), 'c', "compression-method",
+            Description = "Set compression method",
+            DefaultValue = "lz4hc",
+            AllowedValues = "zlib;zlibfast;lz4;lz4hc;none",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string CompressionMethod;
+
+        public static LogLevel GetLogLevelByString(string optionLogLevel)
+        {
+            LogLevel logLevel;
+
+            switch (optionLogLevel)
+            {
+                case "silent":
+                    logLevel = Enums.LogLevel.SILENT;
+                    break;
+                case "info":
+                    logLevel = Enums.LogLevel.INFO;
+                    break;
+                case "warn":
+                    logLevel = Enums.LogLevel.WARN;
+                    break;
+                case "error":
+                    logLevel = Enums.LogLevel.ERROR;
+                    break;
+                case "fatal":
+                    logLevel = Enums.LogLevel.FATAL;
+                    break;
+                case "debug":
+                    logLevel = Enums.LogLevel.DEBUG;
+                    break;
+                default:
+                    logLevel = Enums.LogLevel.INFO;
+                    break;
+            }
+
+            return logLevel;
+        }
+
+        public static Game GetGameByString(string optionGame)
+        {
+            Game game = Enums.Game.DivinityOriginalSin2;
+
+            switch (optionGame)
+            {
+                case "dos":
+                    game = Enums.Game.DivinityOriginalSin;
+                    break;
+                case "dosee":
+                    game = Enums.Game.DivinityOriginalSinEE;
+                    break;
+                case "dos2":
+                    game = Enums.Game.DivinityOriginalSin2;
+                    break;
+            }
+
+            return game;
+        }
+
+        public static int GetFileVersionByGame(Game divinityGame)
+        {
+            return divinityGame == Enums.Game.DivinityOriginalSin2
+                ? (int)LSLib.LS.LSF.FileVersion.VerExtendedNodes
+                : (int)LSLib.LS.LSF.FileVersion.VerChunkedCompress;
+        }
+
+        public static ExportFormat GetExportFormatByString(string optionExportFormat)
+        {
+            return optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
+        }
+
+        public static ResourceFormat GetResourceFormatByString(string optionResourceFormat)
+        {
+            ResourceFormat resourceFormat = ResourceFormat.LSX;
+
+            switch (optionResourceFormat)
+            {
+                case "lsb":
+                    resourceFormat = ResourceFormat.LSB;
+                    break;
+                case "lsf":
+                    resourceFormat = ResourceFormat.LSF;
+                    break;
+                case "lsj":
+                    resourceFormat = ResourceFormat.LSJ;
+                    break;
+                case "lsx":
+                    resourceFormat = ResourceFormat.LSX;
+                    break;
+            }
+
+            return resourceFormat;
+        }
+
+        public static PackageVersion GetPackageVersion(string versionOption)
+        {
+            PackageVersion version;
+            
+            switch (versionOption)
+            {
+                case "v7":
+                    version = Enums.PackageVersion.v7;
+                    break;
+
+                case "v9":
+                    version = Enums.PackageVersion.v9;
+                    break;
+
+                case "v10":
+                    version = Enums.PackageVersion.v10;
+                    break;
+
+                case "v13":
+                    version = Enums.PackageVersion.v13;
+                    break;
+
+                default:
+                    version = Enums.PackageVersion.v13;
+                    break;
+            }
+
+            return version;
+        }
+
+        public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion version)
+        {
+            CompressionMethod compression;
+            bool fastCompression;
+
+            switch (compressionOption)
+            {
+                case "zlibfast":
+                    compression = LSLib.LS.CompressionMethod.Zlib;
+                    fastCompression = true;
+                    break;
+
+                case "zlib":
+                    compression = LSLib.LS.CompressionMethod.Zlib;
+                    fastCompression = false;
+                    break;
+
+                case "lz4":
+                    compression = LSLib.LS.CompressionMethod.LZ4;
+                    fastCompression = true;
+                    break;
+
+                case "lz4hc":
+                    compression = LSLib.LS.CompressionMethod.LZ4;
+                    fastCompression = false;
+                    break;
+
+                default:
+                    compression = LSLib.LS.CompressionMethod.None;
+                    fastCompression = false;
+                    break;
+            }
+
+            // fallback to zlib, if the package version doesn't support lz4
+            if (compression == LSLib.LS.CompressionMethod.LZ4 && version <= (PackageVersion) 9)
+            {
+                compression = LSLib.LS.CompressionMethod.Zlib;
+                fastCompression = false;
+            }
+
+            var compressionOptions = new Dictionary<string, object>
+            {
+                { "Compression", compression },
+                { "FastCompression", fastCompression }
+            };
+
+            return compressionOptions;
+        }
+
+        public static Dictionary<string, bool> GetGraphicsOptions(string[] options)
+        {
+            Dictionary<string, bool> results = new Dictionary<string, bool>
+            {
+                { "export-normals", false },
+                { "export-tangents", false },
+                { "export-uvs", false },
+                { "deduplicate-vertices", false },
+                { "filter-uvs", false },
+                { "recalculate-normals", false },
+                { "recalculate-tangents", false },
+                { "recalculate-iwt", false },
+                { "flip-uvs", false },
+                { "force-legacy-version", false },
+                { "compact-tris", false },
+                { "build-dummy-skeleton", false },
+                { "apply-basis-transforms", false },
+                { "conform", false }
+            };
+
+            if (options == null)
+            {
+                return results;
+            }
+
+            foreach (string option in options)
+            {
+                if (results.Keys.Contains(option))
+                {
+                    results[option] = true;
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -9,24 +9,7 @@ namespace Divine.CLI
 {
     public class CommandLineArguments
     {
-        [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
-            Description = "Set verbosity level of log output",
-            DefaultValue = "info",
-            AllowedValues = "info;warn;error;fatal;debug;silent",
-            ValueOptional = false,
-            Optional = true
-        )]
-        public string LogLevel;
-
-        [EnumeratedValueArgument(typeof(string), 'g', "game",
-            Description = "Set target game when generating output",
-            DefaultValue = "dos2",
-            AllowedValues = "dos;dosee;dos2",
-            ValueOptional = false,
-            Optional = true
-        )]
-        public string Game;
-
+        // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'a', "action",
             Description = "Set action to execute",
             DefaultValue = "extract-package",
@@ -36,14 +19,26 @@ namespace Divine.CLI
         )]
         public string Action;
 
-        [ValueArgument(typeof(string), 's', "source",
-            Description = "Set source file path or directory",
+        // @formatter:off
+        [EnumeratedValueArgument(typeof(string), 'c', "compression-method",
+            Description = "Set compression method",
+            DefaultValue = "lz4hc",
+            AllowedValues = "zlib;zlibfast;lz4;lz4hc;none",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string CompressionMethod;
+
+        // @formatter:off
+        [ValueArgument(typeof(string), "conform-path",
+            Description = "Set conform to original path",
             DefaultValue = null,
             ValueOptional = false,
-            Optional = false
+            Optional = true
         )]
-        public string Source;
+        public string ConformPath;
 
+        // @formatter:off
         [ValueArgument(typeof(string), 'd', "destination",
             Description = "Set destination file path or directory",
             DefaultValue = null,
@@ -52,6 +47,17 @@ namespace Divine.CLI
         )]
         public string Destination;
 
+        // @formatter:off
+        [EnumeratedValueArgument(typeof(string), 'g', "game",
+            Description = "Set target game when generating output",
+            DefaultValue = "dos2",
+            AllowedValues = "dos;dosee;dos2",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string Game;
+
+        // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'i', "input-format",
             Description = "Set input format for batch operations",
             DefaultValue = null,
@@ -61,6 +67,27 @@ namespace Divine.CLI
         )]
         public string InputFormat;
 
+        // @formatter:off
+        [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
+            Description = "Set verbosity level of log output",
+            DefaultValue = "info",
+            AllowedValues = "info;warn;error;fatal;debug;silent",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string LogLevel;
+
+        // @formatter:off
+        [EnumeratedValueArgument(typeof(string), "gr2-options",
+            Description = "Set extra options for GR2/DAE conversion",
+            AllowMultiple = true,
+            AllowedValues = "export-normals;export-tangents;export-uvs;deduplicate-vertices;filter-uvs;recalculate-normals;recalculate-tangents;recalculate-iwt;flip-uvs;force-legacy-version;compact-tris;build-dummy-skeleton;apply-basis-transforms;conform",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string[] Options;
+
+        // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'o', "output-format",
             Description = "Set output format for batch operations",
             DefaultValue = null,
@@ -70,23 +97,7 @@ namespace Divine.CLI
         )]
         public string OutputFormat;
 
-        [EnumeratedValueArgument(typeof(string), "gr2-options", 
-            Description = "Set extra options for GR2/DAE conversion",
-            AllowMultiple = true,
-            AllowedValues = "export-normals;export-tangents;export-uvs;deduplicate-vertices;filter-uvs;recalculate-normals;recalculate-tangents;recalculate-iwt;flip-uvs;force-legacy-version;compact-tris;build-dummy-skeleton;apply-basis-transforms;conform",
-            ValueOptional = false,
-            Optional = true
-        )]
-        public string[] Options;
-
-        [ValueArgument(typeof(string), "conform-path", 
-            Description = "Set conform to original path", 
-            DefaultValue = null,
-            ValueOptional = false,
-            Optional = true
-        )]
-        public string ConformPath;
-
+        // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'p', "package-version",
             Description = "Set package version",
             DefaultValue = "v13",
@@ -96,14 +107,16 @@ namespace Divine.CLI
         )]
         public string PackageVersion;
 
-        [EnumeratedValueArgument(typeof(string), 'c', "compression-method",
-            Description = "Set compression method",
-            DefaultValue = "lz4hc",
-            AllowedValues = "zlib;zlibfast;lz4;lz4hc;none",
+        // @formatter:off
+        [ValueArgument(typeof(string), 's', "source",
+            Description = "Set source file path or directory",
+            DefaultValue = null,
             ValueOptional = false,
-            Optional = true
+            Optional = false
         )]
-        public string CompressionMethod;
+        public string Source;
+
+        // @formatter:on
 
         public static LogLevel GetLogLevelByString(string optionLogLevel)
         {
@@ -145,39 +158,34 @@ namespace Divine.CLI
 
         public static Game GetGameByString(string optionGame)
         {
-            Game game = Enums.Game.DivinityOriginalSin2;
+            Game game;
 
             switch (optionGame)
             {
                 case "dos":
-                    game = Enums.Game.DivinityOriginalSin;
+                    game = LSLib.LS.Enums.Game.DivinityOriginalSin;
                     break;
                 case "dosee":
-                    game = Enums.Game.DivinityOriginalSinEE;
+                    game = LSLib.LS.Enums.Game.DivinityOriginalSinEE;
                     break;
-                case "dos2":
-                    game = Enums.Game.DivinityOriginalSin2;
+//                case "dos2":
+//                    game = LSLib.LS.Enums.Game.DivinityOriginalSin2;
+//                    break;
+                default:
+                    game = LSLib.LS.Enums.Game.DivinityOriginalSin2;
                     break;
             }
 
             return game;
         }
 
-        public static FileVersion GetFileVersionByGame(Game divinityGame)
-        {
-            return divinityGame == Enums.Game.DivinityOriginalSin2
-                ? FileVersion.VerExtendedNodes
-                : FileVersion.VerChunkedCompress;
-        }
+        public static FileVersion GetFileVersionByGame(Game divinityGame) => divinityGame == LSLib.LS.Enums.Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
 
-        public static ExportFormat GetExportFormatByString(string optionExportFormat)
-        {
-            return optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
-        }
+        public static ExportFormat GetExportFormatByString(string optionExportFormat) => optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
 
         public static ResourceFormat GetResourceFormatByString(string optionResourceFormat)
         {
-            ResourceFormat resourceFormat = ResourceFormat.LSX;
+            ResourceFormat resourceFormat;
 
             switch (optionResourceFormat)
             {
@@ -193,6 +201,9 @@ namespace Divine.CLI
                 case "lsx":
                     resourceFormat = ResourceFormat.LSX;
                     break;
+                default:
+                    resourceFormat = ResourceFormat.LSX;
+                    break;
             }
 
             return resourceFormat;
@@ -201,27 +212,27 @@ namespace Divine.CLI
         public static PackageVersion GetPackageVersion(string versionOption)
         {
             PackageVersion version;
-            
+
             switch (versionOption)
             {
                 case "v7":
-                    version = Enums.PackageVersion.v7;
+                    version = Enums.PackageVersion.V7;
                     break;
 
                 case "v9":
-                    version = Enums.PackageVersion.v9;
+                    version = Enums.PackageVersion.V9;
                     break;
 
                 case "v10":
-                    version = Enums.PackageVersion.v10;
+                    version = Enums.PackageVersion.V10;
                     break;
 
                 case "v13":
-                    version = Enums.PackageVersion.v13;
+                    version = Enums.PackageVersion.V13;
                     break;
 
                 default:
-                    version = Enums.PackageVersion.v13;
+                    version = Enums.PackageVersion.V13;
                     break;
             }
 
@@ -268,7 +279,7 @@ namespace Divine.CLI
                 fastCompression = false;
             }
 
-            var compressionOptions = new Dictionary<string, object>
+            Dictionary<string, object> compressionOptions = new Dictionary<string, object>
             {
                 { "Compression", compression },
                 { "FastCompression", fastCompression }

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using CommandLineParser.Arguments;
 using Divine.Enums;
 using LSLib.Granny.Model;
-using LSLib.LS;
+using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
@@ -111,23 +111,29 @@ namespace Divine.CLI
 
             switch (optionLogLevel)
             {
-                case "silent":
-                    logLevel = Enums.LogLevel.SILENT;
-                    break;
-                case "info":
-                    logLevel = Enums.LogLevel.INFO;
-                    break;
-                case "warn":
-                    logLevel = Enums.LogLevel.WARN;
-                    break;
-                case "error":
-                    logLevel = Enums.LogLevel.ERROR;
+                case "off":
+                    logLevel = Enums.LogLevel.OFF;
                     break;
                 case "fatal":
                     logLevel = Enums.LogLevel.FATAL;
                     break;
+                case "error":
+                    logLevel = Enums.LogLevel.ERROR;
+                    break;
+                case "warn":
+                    logLevel = Enums.LogLevel.WARN;
+                    break;
+                case "info":
+                    logLevel = Enums.LogLevel.INFO;
+                    break;
                 case "debug":
                     logLevel = Enums.LogLevel.DEBUG;
+                    break;
+                case "trace":
+                    logLevel = Enums.LogLevel.TRACE;
+                    break;
+                case "all":
+                    logLevel = Enums.LogLevel.ALL;
                     break;
                 default:
                     logLevel = Enums.LogLevel.INFO;
@@ -157,11 +163,11 @@ namespace Divine.CLI
             return game;
         }
 
-        public static int GetFileVersionByGame(Game divinityGame)
+        public static FileVersion GetFileVersionByGame(Game divinityGame)
         {
             return divinityGame == Enums.Game.DivinityOriginalSin2
-                ? (int)LSLib.LS.LSF.FileVersion.VerExtendedNodes
-                : (int)LSLib.LS.LSF.FileVersion.VerChunkedCompress;
+                ? FileVersion.VerExtendedNodes
+                : FileVersion.VerChunkedCompress;
         }
 
         public static ExportFormat GetExportFormatByString(string optionExportFormat)
@@ -230,35 +236,35 @@ namespace Divine.CLI
             switch (compressionOption)
             {
                 case "zlibfast":
-                    compression = LSLib.LS.CompressionMethod.Zlib;
+                    compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                     fastCompression = true;
                     break;
 
                 case "zlib":
-                    compression = LSLib.LS.CompressionMethod.Zlib;
+                    compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                     fastCompression = false;
                     break;
 
                 case "lz4":
-                    compression = LSLib.LS.CompressionMethod.LZ4;
+                    compression = LSLib.LS.Enums.CompressionMethod.LZ4;
                     fastCompression = true;
                     break;
 
                 case "lz4hc":
-                    compression = LSLib.LS.CompressionMethod.LZ4;
+                    compression = LSLib.LS.Enums.CompressionMethod.LZ4;
                     fastCompression = false;
                     break;
 
                 default:
-                    compression = LSLib.LS.CompressionMethod.None;
+                    compression = LSLib.LS.Enums.CompressionMethod.None;
                     fastCompression = false;
                     break;
             }
 
             // fallback to zlib, if the package version doesn't support lz4
-            if (compression == LSLib.LS.CompressionMethod.LZ4 && version <= (PackageVersion) 9)
+            if (compression == LSLib.LS.Enums.CompressionMethod.LZ4 && version <= (PackageVersion) 9)
             {
-                compression = LSLib.LS.CompressionMethod.Zlib;
+                compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                 fastCompression = false;
             }
 
@@ -271,7 +277,7 @@ namespace Divine.CLI
             return compressionOptions;
         }
 
-        public static Dictionary<string, bool> GetGraphicsOptions(string[] options)
+        public static Dictionary<string, bool> GetGR2Options(string[] options)
         {
             Dictionary<string, bool> results = new Dictionary<string, bool>
             {

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Divine.Enums;
 using LSLib.LS;
+using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
@@ -20,7 +20,7 @@ namespace Divine.CLI
             CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game)
         );
 
-        private static void ConvertResource(string sourcePath, string destinationPath, int fileVersion)
+        private static void ConvertResource(string sourcePath, string destinationPath, FileVersion fileVersion)
         {
             try
             {
@@ -33,11 +33,12 @@ namespace Divine.CLI
             }
             catch (Exception e)
             {
-                CommandLineLogger.LogFatal($"Failed to convert resource: {e.Message}{Environment.NewLine}{e.StackTrace}");
+                CommandLineLogger.LogFatal($"Failed to convert resource: {e.Message}", 2);
+                CommandLineLogger.LogTrace($"{e.StackTrace}");
             }
         }
 
-        private static void BatchConvertResource(string sourcePath, string destinationPath, ResourceFormat inputFormat, ResourceFormat outputFormat, int fileVersion)
+        private static void BatchConvertResource(string sourcePath, string destinationPath, ResourceFormat inputFormat, ResourceFormat outputFormat, FileVersion fileVersion)
         {
             try
             {
@@ -49,7 +50,8 @@ namespace Divine.CLI
             }
             catch (Exception e)
             {
-                CommandLineLogger.LogFatal($"Failed to batch convert resources: {e.Message}{Environment.NewLine}{e.StackTrace}");
+                CommandLineLogger.LogFatal($"Failed to batch convert resources: {e.Message}", 2);
+                CommandLineLogger.LogTrace($"{e.StackTrace}");
             }
         }
     }

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Divine.Enums;
+using LSLib.LS;
+
+namespace Divine.CLI
+{
+    internal class CommandLineDataProcessor
+    {
+        public static void Convert() => ConvertResource(
+            CommandLineActions.SourcePath,
+            CommandLineActions.DestinationPath,
+            CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game)
+        );
+
+        public static void BatchConvert() => BatchConvertResource(
+            CommandLineActions.SourcePath,
+            CommandLineActions.DestinationPath,
+            CommandLineActions.InputFormat,
+            CommandLineActions.OutputFormat,
+            CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game)
+        );
+
+        private static void ConvertResource(string sourcePath, string destinationPath, int fileVersion)
+        {
+            try
+            {
+                Resource resource = ResourceUtils.LoadResource(sourcePath);
+                ResourceFormat resourceFormat = ResourceUtils.ExtensionToResourceFormat(sourcePath);
+
+                ResourceUtils.SaveResource(resource, destinationPath, resourceFormat, fileVersion);
+
+                CommandLineLogger.LogInfo($"Wrote resource to: {destinationPath}");
+            }
+            catch (Exception e)
+            {
+                CommandLineLogger.LogFatal($"Failed to convert resource: {e.Message}{Environment.NewLine}{e.StackTrace}");
+            }
+        }
+
+        private static void BatchConvertResource(string sourcePath, string destinationPath, ResourceFormat inputFormat, ResourceFormat outputFormat, int fileVersion)
+        {
+            try
+            {
+                ResourceUtils resourceUtils = new ResourceUtils();
+
+                resourceUtils.ConvertResources(sourcePath, destinationPath, inputFormat, outputFormat, fileVersion);
+
+                CommandLineLogger.LogInfo($"Wrote resources to: {destinationPath}");
+            }
+            catch (Exception e)
+            {
+                CommandLineLogger.LogFatal($"Failed to batch convert resources: {e.Message}{Environment.NewLine}{e.StackTrace}");
+            }
+        }
+    }
+}

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -6,19 +6,15 @@ namespace Divine.CLI
 {
     internal class CommandLineDataProcessor
     {
-        public static void Convert() => ConvertResource(
-            CommandLineActions.SourcePath,
-            CommandLineActions.DestinationPath,
-            CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game)
-        );
+        public static void Convert()
+        {
+            ConvertResource(CommandLineActions.SourcePath, CommandLineActions.DestinationPath, CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game));
+        }
 
-        public static void BatchConvert() => BatchConvertResource(
-            CommandLineActions.SourcePath,
-            CommandLineActions.DestinationPath,
-            CommandLineActions.InputFormat,
-            CommandLineActions.OutputFormat,
-            CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game)
-        );
+        public static void BatchConvert()
+        {
+            BatchConvertResource(CommandLineActions.SourcePath, CommandLineActions.DestinationPath, CommandLineActions.InputFormat, CommandLineActions.OutputFormat, CommandLineArguments.GetFileVersionByGame(CommandLineActions.Game));
+        }
 
         private static void ConvertResource(string sourcePath, string destinationPath, FileVersion fileVersion)
         {
@@ -42,7 +38,7 @@ namespace Divine.CLI
         {
             try
             {
-                ResourceUtils resourceUtils = new ResourceUtils();
+                var resourceUtils = new ResourceUtils();
 
                 resourceUtils.ConvertResources(sourcePath, destinationPath, inputFormat, outputFormat, fileVersion);
 

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -6,9 +6,9 @@ using LSLib.Granny.Model;
 
 namespace Divine.CLI
 {
-    internal class CommandLineGraphicsProcessor
+    internal class CommandLineGR2Processor
     {
-        private static readonly Dictionary<string, bool> GraphicsOptions = CommandLineActions.GraphicsOptions;
+        private static readonly Dictionary<string, bool> GR2Options = CommandLineActions.GR2Options;
 
         public static void Convert(string file = "") => ConvertResource(file);
 
@@ -22,20 +22,20 @@ namespace Divine.CLI
                 OutputPath = CommandLineActions.DestinationPath,
                 InputFormat = CommandLineArguments.GetExportFormatByString(Program.argv.InputFormat),
                 OutputFormat = CommandLineArguments.GetExportFormatByString(Program.argv.OutputFormat),
-                ExportNormals = GraphicsOptions["export-normals"],
-                ExportTangents = GraphicsOptions["export-tangents"],
-                ExportUVs = GraphicsOptions["export-uvs"],
-                FlipUVs = GraphicsOptions["flip-uvs"],
-                RecalculateNormals = GraphicsOptions["recalculate-normals"],
-                RecalculateTangents = GraphicsOptions["recalculate-tangents"],
-                RecalculateIWT = GraphicsOptions["recalculate-iwt"],
-                BuildDummySkeleton = GraphicsOptions["build-dummy-skeleton"],
-                CompactIndices = GraphicsOptions["compact-tris"],
-                DeduplicateVertices = GraphicsOptions["deduplicate-vertices"],
-                DeduplicateUVs = GraphicsOptions["deduplicate-uvs"],
-                ApplyBasisTransforms = GraphicsOptions["apply-basis-transforms"],
-                UseObsoleteVersionTag = GraphicsOptions["force-legacy-version"],
-                ConformGR2Path = GraphicsOptions["conform"] && !string.IsNullOrEmpty(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null
+                ExportNormals = GR2Options["export-normals"],
+                ExportTangents = GR2Options["export-tangents"],
+                ExportUVs = GR2Options["export-uvs"],
+                FlipUVs = GR2Options["flip-uvs"],
+                RecalculateNormals = GR2Options["recalculate-normals"],
+                RecalculateTangents = GR2Options["recalculate-tangents"],
+                RecalculateIWT = GR2Options["recalculate-iwt"],
+                BuildDummySkeleton = GR2Options["build-dummy-skeleton"],
+                CompactIndices = GR2Options["compact-tris"],
+                DeduplicateVertices = GR2Options["deduplicate-vertices"],
+                DeduplicateUVs = GR2Options["deduplicate-uvs"],
+                ApplyBasisTransforms = GR2Options["apply-basis-transforms"],
+                UseObsoleteVersionTag = GR2Options["force-legacy-version"],
+                ConformGR2Path = GR2Options["conform"] && !string.IsNullOrEmpty(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null
             };
 
             if (CommandLineActions.Game == Game.DivinityOriginalSin)
@@ -70,7 +70,8 @@ namespace Divine.CLI
             }
             catch (Exception e)
             {
-                CommandLineLogger.LogFatal($"Export failed: {e.Message}{Environment.NewLine}{e.StackTrace}");
+                CommandLineLogger.LogFatal($"Export failed: {e.Message}", 2);
+                CommandLineLogger.LogTrace($"{e.StackTrace}");
             }
         }
 
@@ -80,7 +81,7 @@ namespace Divine.CLI
 
             if (files.Length == 0)
             {
-                CommandLineLogger.LogFatal($"Batch convert failed: *.{inputFormat} not found in source path");
+                CommandLineLogger.LogFatal($"Batch convert failed: *.{inputFormat} not found in source path", 1);
             }
 
             foreach (string file in files)

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Divine.Enums;
+using LSLib.Granny.GR2;
 using LSLib.Granny.Model;
+using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
@@ -16,7 +17,7 @@ namespace Divine.CLI
 
         public static ExporterOptions UpdateExporterSettings()
         {
-            ExporterOptions exporterOptions = new ExporterOptions
+            var exporterOptions = new ExporterOptions
             {
                 InputPath = CommandLineActions.SourcePath,
                 OutputPath = CommandLineActions.DestinationPath,
@@ -42,13 +43,13 @@ namespace Divine.CLI
             {
                 exporterOptions.Is64Bit = false;
                 exporterOptions.AlternateSignature = false;
-                exporterOptions.VersionTag = LSLib.Granny.GR2.Header.Tag_DOS;
+                exporterOptions.VersionTag = Header.Tag_DOS;
             }
             else
             {
                 exporterOptions.Is64Bit = true;
                 exporterOptions.AlternateSignature = true;
-                exporterOptions.VersionTag = LSLib.Granny.GR2.Header.Tag_DOSEE;
+                exporterOptions.VersionTag = Header.Tag_DOSEE;
             }
 
             return exporterOptions;
@@ -56,7 +57,10 @@ namespace Divine.CLI
 
         private static void ConvertResource(string file)
         {
-            Exporter exporter = new Exporter { Options = UpdateExporterSettings() };
+            var exporter = new Exporter
+            {
+                Options = UpdateExporterSettings()
+            };
 
             if (!string.IsNullOrEmpty(file))
             {

--- a/Divine/CLI/CommandLineGraphicsProcessor.cs
+++ b/Divine/CLI/CommandLineGraphicsProcessor.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Divine.Enums;
+using LSLib.Granny.Model;
+
+namespace Divine.CLI
+{
+    internal class CommandLineGraphicsProcessor
+    {
+        private static readonly Dictionary<string, bool> GraphicsOptions = CommandLineActions.GraphicsOptions;
+
+        public static void Convert(string file = "") => ConvertResource(file);
+
+        public static void BatchConvert() => BatchConvertResources(CommandLineActions.SourcePath, Program.argv.InputFormat);
+
+        public static ExporterOptions UpdateExporterSettings()
+        {
+            ExporterOptions exporterOptions = new ExporterOptions
+            {
+                InputPath = CommandLineActions.SourcePath,
+                OutputPath = CommandLineActions.DestinationPath,
+                InputFormat = CommandLineArguments.GetExportFormatByString(Program.argv.InputFormat),
+                OutputFormat = CommandLineArguments.GetExportFormatByString(Program.argv.OutputFormat),
+                ExportNormals = GraphicsOptions["export-normals"],
+                ExportTangents = GraphicsOptions["export-tangents"],
+                ExportUVs = GraphicsOptions["export-uvs"],
+                FlipUVs = GraphicsOptions["flip-uvs"],
+                RecalculateNormals = GraphicsOptions["recalculate-normals"],
+                RecalculateTangents = GraphicsOptions["recalculate-tangents"],
+                RecalculateIWT = GraphicsOptions["recalculate-iwt"],
+                BuildDummySkeleton = GraphicsOptions["build-dummy-skeleton"],
+                CompactIndices = GraphicsOptions["compact-tris"],
+                DeduplicateVertices = GraphicsOptions["deduplicate-vertices"],
+                DeduplicateUVs = GraphicsOptions["deduplicate-uvs"],
+                ApplyBasisTransforms = GraphicsOptions["apply-basis-transforms"],
+                UseObsoleteVersionTag = GraphicsOptions["force-legacy-version"],
+                ConformGR2Path = GraphicsOptions["conform"] && !string.IsNullOrEmpty(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null
+            };
+
+            if (CommandLineActions.Game == Game.DivinityOriginalSin)
+            {
+                exporterOptions.Is64Bit = false;
+                exporterOptions.AlternateSignature = false;
+                exporterOptions.VersionTag = LSLib.Granny.GR2.Header.Tag_DOS;
+            }
+            else
+            {
+                exporterOptions.Is64Bit = true;
+                exporterOptions.AlternateSignature = true;
+                exporterOptions.VersionTag = LSLib.Granny.GR2.Header.Tag_DOSEE;
+            }
+
+            return exporterOptions;
+        }
+
+        private static void ConvertResource(string file)
+        {
+            Exporter exporter = new Exporter { Options = UpdateExporterSettings() };
+
+            if (!string.IsNullOrEmpty(file))
+            {
+                exporter.Options.InputPath = file;
+            }
+
+            try
+            {
+                exporter.Export();
+                CommandLineLogger.LogInfo("Export completed successfully.");
+            }
+            catch (Exception e)
+            {
+                CommandLineLogger.LogFatal($"Export failed: {e.Message}{Environment.NewLine}{e.StackTrace}");
+            }
+        }
+
+        private static void BatchConvertResources(string sourcePath, string inputFormat)
+        {
+            string[] files = Directory.GetFiles(sourcePath, $"*.{inputFormat}");
+
+            if (files.Length == 0)
+            {
+                CommandLineLogger.LogFatal($"Batch convert failed: *.{inputFormat} not found in source path");
+            }
+
+            foreach (string file in files)
+            {
+                UpdateExporterSettings();
+                Convert(file);
+            }
+        }
+    }
+}

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -7,26 +7,34 @@ namespace Divine.CLI
     {
         private static readonly LogLevel optionLogLevel = CommandLineActions.LogLevel;
 
-        public static void LogInfo(string message) => Log(LogLevel.INFO, message);
-        public static void LogWarn(string message) => Log(LogLevel.WARN, message);
+        public static void LogFatal(string message, int errorCode) => Log(LogLevel.FATAL, message, errorCode);
         public static void LogError(string message) => Log(LogLevel.ERROR, message);
-        public static void LogFatal(string message) => Log(LogLevel.FATAL, message);
+        public static void LogWarn(string message) => Log(LogLevel.WARN, message);
+        public static void LogInfo(string message) => Log(LogLevel.INFO, message);
         public static void LogDebug(string message) => Log(LogLevel.DEBUG, message);
+        public static void LogTrace(string message) => Log(LogLevel.TRACE, message);
+        public static void LogAll(string message) => Log(LogLevel.ALL, message);
 
-        private static void Log(LogLevel loglevel, string message)
+        private static void Log(LogLevel loglevel, string message, int errorCode = -1)
         {
-            if (optionLogLevel == LogLevel.SILENT) return;
+            if (optionLogLevel == LogLevel.OFF) return;
 
             switch (loglevel)
             {
-                case LogLevel.INFO:
-                    if (optionLogLevel < LogLevel.INFO) break;
-                    Console.WriteLine($"[INFO] {message}");
-                    break;
+                case LogLevel.FATAL:
+                    if (optionLogLevel > LogLevel.OFF)
+                    {
+                        Console.WriteLine($"[FATAL] {message}");
+                    }
 
-                case LogLevel.WARN:
-                    if (optionLogLevel < LogLevel.WARN) break;
-                    Console.WriteLine($"[WARN] {message}");
+                    if (errorCode == -1)
+                    {
+                        Environment.Exit((int) LogLevel.FATAL);
+                    }
+                    else
+                    {
+                        Environment.Exit((int)LogLevel.FATAL + errorCode);
+                    }
                     break;
 
                 case LogLevel.ERROR:
@@ -34,17 +42,24 @@ namespace Divine.CLI
                     Console.WriteLine($"[ERROR] {message}");
                     break;
 
-                case LogLevel.FATAL:
-                    if (optionLogLevel > LogLevel.SILENT)
-                    {
-                        Console.WriteLine($"[FATAL] {message}");
-                    }
-                    Environment.Exit((int) LogLevel.FATAL);
+                case LogLevel.WARN:
+                    if (optionLogLevel < LogLevel.WARN) break;
+                    Console.WriteLine($"[WARN] {message}");
+                    break;
+
+                case LogLevel.INFO:
+                    if (optionLogLevel < LogLevel.INFO) break;
+                    Console.WriteLine($"[INFO] {message}");
                     break;
 
                 case LogLevel.DEBUG:
                     if (optionLogLevel < LogLevel.DEBUG) break;
                     Console.WriteLine($"[DEBUG] {message}");
+                    break;
+
+                case LogLevel.TRACE:
+                    if (optionLogLevel < LogLevel.TRACE) break;
+                    Console.WriteLine($"[TRACE] {message}");
                     break;
             }
         }

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -5,7 +5,7 @@ namespace Divine.CLI
 {
     internal class CommandLineLogger
     {
-        private static readonly LogLevel optionLogLevel = CommandLineActions.LogLevel;
+        private static readonly LogLevel OptionLogLevel = CommandLineActions.LogLevel;
 
         public static void LogFatal(string message, int errorCode) => Log(LogLevel.FATAL, message, errorCode);
         public static void LogError(string message) => Log(LogLevel.ERROR, message);
@@ -17,12 +17,15 @@ namespace Divine.CLI
 
         private static void Log(LogLevel loglevel, string message, int errorCode = -1)
         {
-            if (optionLogLevel == LogLevel.OFF) return;
+            if (OptionLogLevel == LogLevel.OFF)
+            {
+                return;
+            }
 
             switch (loglevel)
             {
                 case LogLevel.FATAL:
-                    if (optionLogLevel > LogLevel.OFF)
+                    if (OptionLogLevel > LogLevel.OFF)
                     {
                         Console.WriteLine($"[FATAL] {message}");
                     }
@@ -33,32 +36,47 @@ namespace Divine.CLI
                     }
                     else
                     {
-                        Environment.Exit((int)LogLevel.FATAL + errorCode);
+                        Environment.Exit((int) LogLevel.FATAL + errorCode);
                     }
                     break;
 
                 case LogLevel.ERROR:
-                    if (optionLogLevel < LogLevel.ERROR) break;
+                    if (OptionLogLevel < LogLevel.ERROR)
+                    {
+                        break;
+                    }
                     Console.WriteLine($"[ERROR] {message}");
                     break;
 
                 case LogLevel.WARN:
-                    if (optionLogLevel < LogLevel.WARN) break;
+                    if (OptionLogLevel < LogLevel.WARN)
+                    {
+                        break;
+                    }
                     Console.WriteLine($"[WARN] {message}");
                     break;
 
                 case LogLevel.INFO:
-                    if (optionLogLevel < LogLevel.INFO) break;
+                    if (OptionLogLevel < LogLevel.INFO)
+                    {
+                        break;
+                    }
                     Console.WriteLine($"[INFO] {message}");
                     break;
 
                 case LogLevel.DEBUG:
-                    if (optionLogLevel < LogLevel.DEBUG) break;
+                    if (OptionLogLevel < LogLevel.DEBUG)
+                    {
+                        break;
+                    }
                     Console.WriteLine($"[DEBUG] {message}");
                     break;
 
                 case LogLevel.TRACE:
-                    if (optionLogLevel < LogLevel.TRACE) break;
+                    if (OptionLogLevel < LogLevel.TRACE)
+                    {
+                        break;
+                    }
                     Console.WriteLine($"[TRACE] {message}");
                     break;
             }

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Divine.Enums;
+
+namespace Divine.CLI
+{
+    internal class CommandLineLogger
+    {
+        private static readonly LogLevel optionLogLevel = CommandLineActions.LogLevel;
+
+        public static void LogInfo(string message) => Log(LogLevel.INFO, message);
+        public static void LogWarn(string message) => Log(LogLevel.WARN, message);
+        public static void LogError(string message) => Log(LogLevel.ERROR, message);
+        public static void LogFatal(string message) => Log(LogLevel.FATAL, message);
+        public static void LogDebug(string message) => Log(LogLevel.DEBUG, message);
+
+        private static void Log(LogLevel loglevel, string message)
+        {
+            if (optionLogLevel == LogLevel.SILENT) return;
+
+            switch (loglevel)
+            {
+                case LogLevel.INFO:
+                    if (optionLogLevel < LogLevel.INFO) break;
+                    Console.WriteLine($"[INFO] {message}");
+                    break;
+
+                case LogLevel.WARN:
+                    if (optionLogLevel < LogLevel.WARN) break;
+                    Console.WriteLine($"[WARN] {message}");
+                    break;
+
+                case LogLevel.ERROR:
+                    if (optionLogLevel < LogLevel.ERROR) break;
+                    Console.WriteLine($"[ERROR] {message}");
+                    break;
+
+                case LogLevel.FATAL:
+                    if (optionLogLevel > LogLevel.SILENT)
+                    {
+                        Console.WriteLine($"[FATAL] {message}");
+                    }
+                    Environment.Exit((int) LogLevel.FATAL);
+                    break;
+
+                case LogLevel.DEBUG:
+                    if (optionLogLevel < LogLevel.DEBUG) break;
+                    Console.WriteLine($"[DEBUG] {message}");
+                    break;
+            }
+        }
+    }
+}

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -5,7 +5,7 @@ namespace Divine.CLI
 {
     internal class CommandLineLogger
     {
-        private static readonly LogLevel OptionLogLevel = CommandLineActions.LogLevel;
+        private static readonly LogLevel LogLevelOption = CommandLineActions.LogLevel;
 
         public static void LogFatal(string message, int errorCode) => Log(LogLevel.FATAL, message, errorCode);
         public static void LogError(string message) => Log(LogLevel.ERROR, message);
@@ -15,17 +15,17 @@ namespace Divine.CLI
         public static void LogTrace(string message) => Log(LogLevel.TRACE, message);
         public static void LogAll(string message) => Log(LogLevel.ALL, message);
 
-        private static void Log(LogLevel loglevel, string message, int errorCode = -1)
+        private static void Log(LogLevel logLevel, string message, int errorCode = -1)
         {
-            if (OptionLogLevel == LogLevel.OFF)
+            if (LogLevelOption == LogLevel.OFF && logLevel != LogLevel.FATAL)
             {
                 return;
             }
 
-            switch (loglevel)
+            switch (logLevel)
             {
                 case LogLevel.FATAL:
-                    if (OptionLogLevel > LogLevel.OFF)
+                    if (LogLevelOption > LogLevel.OFF)
                     {
                         Console.WriteLine($"[FATAL] {message}");
                     }
@@ -41,7 +41,7 @@ namespace Divine.CLI
                     break;
 
                 case LogLevel.ERROR:
-                    if (OptionLogLevel < LogLevel.ERROR)
+                    if (LogLevelOption < logLevel)
                     {
                         break;
                     }
@@ -49,7 +49,7 @@ namespace Divine.CLI
                     break;
 
                 case LogLevel.WARN:
-                    if (OptionLogLevel < LogLevel.WARN)
+                    if (LogLevelOption < logLevel)
                     {
                         break;
                     }
@@ -57,7 +57,7 @@ namespace Divine.CLI
                     break;
 
                 case LogLevel.INFO:
-                    if (OptionLogLevel < LogLevel.INFO)
+                    if (LogLevelOption < logLevel)
                     {
                         break;
                     }
@@ -65,7 +65,7 @@ namespace Divine.CLI
                     break;
 
                 case LogLevel.DEBUG:
-                    if (OptionLogLevel < LogLevel.DEBUG)
+                    if (LogLevelOption < logLevel)
                     {
                         break;
                     }
@@ -73,7 +73,7 @@ namespace Divine.CLI
                     break;
 
                 case LogLevel.TRACE:
-                    if (OptionLogLevel < LogLevel.TRACE)
+                    if (LogLevelOption < logLevel)
                     {
                         break;
                     }

--- a/Divine/CLI/CommandLinePackageProcessor.cs
+++ b/Divine/CLI/CommandLinePackageProcessor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Divine.Enums;
 using LSLib.LS;
@@ -10,25 +9,26 @@ namespace Divine.CLI
 {
     internal class CommandLinePackageProcessor
     {
-        private static readonly CommandLineArguments args = Program.argv;
+        private static readonly CommandLineArguments Args = Program.argv;
 
         public static void Create() => CreatePackageResource();
 
-        [SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
         public static void Extract()
         {
             if (CommandLineActions.SourcePath == null)
             {
                 CommandLineLogger.LogFatal("Cannot extract package without source path", 1);
             }
-
-            string extractionPath = Path.Combine(CommandLineActions.DestinationPath, Path.GetFileNameWithoutExtension(CommandLineActions.SourcePath));
-            ExtractPackageResource(CommandLineActions.SourcePath, extractionPath);
+            else
+            {
+                string extractionPath = Path.Combine(CommandLineActions.DestinationPath, Path.GetFileNameWithoutExtension(CommandLineActions.SourcePath));
+                ExtractPackageResource(CommandLineActions.SourcePath, extractionPath);
+            }
         }
 
         public static void BatchExtract()
         {
-            string[] files = Directory.GetFiles(CommandLineActions.SourcePath, $"*.{args.InputFormat}");
+            string[] files = Directory.GetFiles(CommandLineActions.SourcePath, $"*.{Args.InputFormat}");
 
             foreach (string file in files)
             {
@@ -48,15 +48,15 @@ namespace Divine.CLI
             }
 
             PackageVersion version = CommandLineActions.PackageVersion;
-            Dictionary<string, object> compressionOptions = CommandLineArguments.GetCompressionOptions(Path.GetExtension(file)?.ToLower() == ".lsv" ? "zlib" : args.CompressionMethod, version);
+            Dictionary<string, object> compressionOptions = CommandLineArguments.GetCompressionOptions(Path.GetExtension(file)?.ToLower() == ".lsv" ? "zlib" : Args.CompressionMethod, version);
 
-            CompressionMethod compressionMethod = (CompressionMethod)compressionOptions["Compression"];
-            bool compressionSpeed = (bool)compressionOptions["FastCompression"];
+            var compressionMethod = (CompressionMethod) compressionOptions["Compression"];
+            var compressionSpeed = (bool) compressionOptions["FastCompression"];
 
             CommandLineLogger.LogDebug($"Using compression method: {compressionMethod.ToString()}");
             CommandLineLogger.LogDebug($"Using fast compression: {compressionSpeed}");
 
-            Packager packager = new Packager();
+            var packager = new Packager();
             packager.CreatePackage(file, CommandLineActions.SourcePath, (uint) version, compressionMethod, compressionSpeed);
 
             CommandLineLogger.LogInfo("Package created successfully.");
@@ -72,7 +72,7 @@ namespace Divine.CLI
 
             try
             {
-                Packager packager = new Packager();
+                var packager = new Packager();
                 string extractionPath = Path.Combine(CommandLineActions.DestinationPath, folder);
                 packager.UncompressPackage(file, extractionPath);
 
@@ -88,7 +88,5 @@ namespace Divine.CLI
                 CommandLineLogger.LogTrace($"{e.StackTrace}");
             }
         }
-
-        
     }
 }

--- a/Divine/CLI/CommandLinePackageProcessor.cs
+++ b/Divine/CLI/CommandLinePackageProcessor.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Divine.Enums;
+using LSLib.LS;
+
+namespace Divine.CLI
+{
+    internal class CommandLinePackageProcessor
+    {
+        private static readonly CommandLineArguments args = Program.argv;
+
+        public static void Create() => CreatePackageResource();
+
+        [SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
+        public static void Extract()
+        {
+            if (CommandLineActions.SourcePath == null)
+            {
+                CommandLineLogger.LogFatal("Cannot extract package without non-null source path");
+            }
+
+            string extractionPath = Path.Combine(CommandLineActions.DestinationPath, Path.GetFileNameWithoutExtension(CommandLineActions.SourcePath));
+            ExtractPackageResource(CommandLineActions.SourcePath, extractionPath);
+        }
+
+        public static void BatchExtract()
+        {
+            string[] files = Directory.GetFiles(CommandLineActions.SourcePath, $"*.{args.InputFormat}");
+
+            foreach (string file in files)
+            {
+                string packageName = Path.GetFileNameWithoutExtension(file);
+
+                CommandLineLogger.LogDebug($"Extracting package: {file}");
+                ExtractPackageResource(file, packageName);
+            }
+        }
+
+        private static void CreatePackageResource(string file = "")
+        {
+            if (string.IsNullOrEmpty(file))
+            {
+                file = CommandLineActions.DestinationPath;
+                CommandLineLogger.LogDebug($"Using destination path: {file}");
+            }
+
+            PackageVersion version = CommandLineActions.PackageVersion;
+            Dictionary<string, object> compressionOptions = CommandLineArguments.GetCompressionOptions(Path.GetExtension(file)?.ToLower() == ".lsv" ? "zlib" : args.CompressionMethod, version);
+
+            CompressionMethod compressionMethod = (CompressionMethod)compressionOptions["Compression"];
+            bool compressionSpeed = (bool)compressionOptions["FastCompression"];
+
+            CommandLineLogger.LogDebug($"Using compression method: {compressionMethod.ToString()}");
+            CommandLineLogger.LogDebug($"Using fast compression: {compressionSpeed}");
+
+            Packager packager = new Packager();
+            packager.CreatePackage(file, CommandLineActions.SourcePath, (uint) version, compressionMethod, compressionSpeed);
+
+            CommandLineLogger.LogInfo("Package created successfully.");
+        }
+
+        private static void ExtractPackageResource(string file = "", string folder = "")
+        {
+            if (string.IsNullOrEmpty(file))
+            {
+                file = CommandLineActions.SourcePath;
+                CommandLineLogger.LogDebug($"Using source path: {file}");
+            }
+
+            try
+            {
+                Packager packager = new Packager();
+                string extractionPath = Path.Combine(CommandLineActions.DestinationPath, folder);
+                packager.UncompressPackage(file, extractionPath);
+
+                CommandLineLogger.LogInfo($"Extracted package to: {extractionPath}");
+            }
+            catch (NotAPackageException)
+            {
+                CommandLineLogger.LogFatal("Failed to extract package because the package is not an Original Sin package or savegame archive");
+            }
+            catch (Exception e)
+            {
+                CommandLineLogger.LogFatal($"Failed to extract package: {e.Message}{Environment.NewLine}{e.StackTrace}");
+            }
+        }
+
+        
+    }
+}

--- a/Divine/CLI/CommandLinePackageProcessor.cs
+++ b/Divine/CLI/CommandLinePackageProcessor.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Divine.Enums;
 using LSLib.LS;
+using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
@@ -19,7 +19,7 @@ namespace Divine.CLI
         {
             if (CommandLineActions.SourcePath == null)
             {
-                CommandLineLogger.LogFatal("Cannot extract package without non-null source path");
+                CommandLineLogger.LogFatal("Cannot extract package without source path", 1);
             }
 
             string extractionPath = Path.Combine(CommandLineActions.DestinationPath, Path.GetFileNameWithoutExtension(CommandLineActions.SourcePath));
@@ -80,11 +80,12 @@ namespace Divine.CLI
             }
             catch (NotAPackageException)
             {
-                CommandLineLogger.LogFatal("Failed to extract package because the package is not an Original Sin package or savegame archive");
+                CommandLineLogger.LogFatal("Failed to extract package because the package is not an Original Sin package or savegame archive", 1);
             }
             catch (Exception e)
             {
-                CommandLineLogger.LogFatal($"Failed to extract package: {e.Message}{Environment.NewLine}{e.StackTrace}");
+                CommandLineLogger.LogFatal($"Failed to extract package: {e.Message}", 2);
+                CommandLineLogger.LogTrace($"{e.StackTrace}");
             }
         }
 

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Divine</RootNamespace>
-    <AssemblyName>Divine</AssemblyName>
+    <AssemblyName>divine</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Divine</RootNamespace>
+    <AssemblyName>Divine</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="CommandLineArgumentsParser, Version=3.0.18.0, Culture=neutral, PublicKeyToken=16ad7bf6f4a1666c, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineArgumentsParser.3.0.18\lib\net45\CommandLineArgumentsParser.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CLI\CommandLineActions.cs" />
+    <Compile Include="CLI\CommandLineDataProcessor.cs" />
+    <Compile Include="CLI\CommandLineGraphicsProcessor.cs" />
+    <Compile Include="CLI\CommandLineLogger.cs" />
+    <Compile Include="CLI\CommandLinePackageProcessor.cs" />
+    <Compile Include="CLI\CommandLineArguments.cs" />
+    <Compile Include="Enums\Game.cs" />
+    <Compile Include="Enums\LogLevel.cs" />
+    <Compile Include="Enums\PackageVersion.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LSLib\LSLib.csproj">
+      <Project>{46372c50-4288-4b8e-af21-c934560600e0}</Project>
+      <Name>LSLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -53,7 +53,6 @@
     <Compile Include="CLI\CommandLineLogger.cs" />
     <Compile Include="CLI\CommandLinePackageProcessor.cs" />
     <Compile Include="CLI\CommandLineArguments.cs" />
-    <Compile Include="Enums\Game.cs" />
     <Compile Include="Enums\LogLevel.cs" />
     <Compile Include="Enums\PackageVersion.cs" />
     <Compile Include="Program.cs" />

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -49,7 +49,7 @@
   <ItemGroup>
     <Compile Include="CLI\CommandLineActions.cs" />
     <Compile Include="CLI\CommandLineDataProcessor.cs" />
-    <Compile Include="CLI\CommandLineGraphicsProcessor.cs" />
+    <Compile Include="CLI\CommandLineGR2Processor.cs" />
     <Compile Include="CLI\CommandLineLogger.cs" />
     <Compile Include="CLI\CommandLinePackageProcessor.cs" />
     <Compile Include="CLI\CommandLineArguments.cs" />

--- a/Divine/Enums/Game.cs
+++ b/Divine/Enums/Game.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Divine.Enums
+﻿namespace Divine.Enums
 {
     public enum Game
     {

--- a/Divine/Enums/Game.cs
+++ b/Divine/Enums/Game.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Divine.Enums
+{
+    public enum Game
+    {
+        DivinityOriginalSin = 0,
+        DivinityOriginalSinEE = 1,
+        DivinityOriginalSin2 = 2
+    };
+}

--- a/Divine/Enums/LogLevel.cs
+++ b/Divine/Enums/LogLevel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Divine.Enums
+{
+    public enum LogLevel
+    {
+        SILENT = 0,
+        INFO = 1,
+        WARN = 2,
+        ERROR = 3,
+        FATAL = 4,
+        DEBUG = 5
+    }
+}

--- a/Divine/Enums/LogLevel.cs
+++ b/Divine/Enums/LogLevel.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Divine.Enums
+﻿namespace Divine.Enums
 {
     public enum LogLevel
     {
-        SILENT = 0,
-        INFO = 1,
-        WARN = 2,
-        ERROR = 3,
-        FATAL = 4,
-        DEBUG = 5
+        OFF = 0,
+        FATAL = 100,
+        ERROR = 200,
+        WARN = 300,
+        INFO = 400,
+        DEBUG = 500,
+        TRACE = 600,
+        ALL = 1000
     }
 }

--- a/Divine/Enums/LogLevel.cs
+++ b/Divine/Enums/LogLevel.cs
@@ -1,4 +1,5 @@
-﻿namespace Divine.Enums
+﻿// ReSharper disable InconsistentNaming
+namespace Divine.Enums
 {
     public enum LogLevel
     {

--- a/Divine/Enums/PackageVersion.cs
+++ b/Divine/Enums/PackageVersion.cs
@@ -1,0 +1,10 @@
+﻿namespace Divine.Enums
+{
+    public enum PackageVersion
+    {
+        v7 = 7,
+        v9 = 9,
+        v10 = 10,
+        v13 = 13
+    };
+}

--- a/Divine/Enums/PackageVersion.cs
+++ b/Divine/Enums/PackageVersion.cs
@@ -2,9 +2,9 @@
 {
     public enum PackageVersion
     {
-        v7 = 7,
-        v9 = 9,
-        v10 = 10,
-        v13 = 13
+        V7 = 7,
+        V9 = 9,
+        V10 = 10,
+        V13 = 13
     };
 }

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Divine.CLI;
+using Divine.Enums;
+
+namespace Divine
+{
+    internal class Program
+    {
+        public static CommandLineArguments argv;
+
+        private static void Main(string[] args)
+        {
+            CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser { IgnoreCase = true, ShowUsageOnEmptyCommandline = true };
+
+            argv = new CommandLineArguments();
+
+            parser.ExtractArgumentAttributes(argv);
+
+            try
+            {
+                parser.ParseCommandLine(args);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[FATAL] {e.Message}");
+            }
+
+            if (parser.ParsingSucceeded)
+            {
+                CommandLineActions.Run(argv);
+            }
+        }
+    }
+}

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Divine.CLI;
-using Divine.Enums;
 
 namespace Divine
 {
@@ -10,7 +9,11 @@ namespace Divine
 
         private static void Main(string[] args)
         {
-            CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser { IgnoreCase = true, ShowUsageOnEmptyCommandline = true };
+            var parser = new CommandLineParser.CommandLineParser
+            {
+                IgnoreCase = true,
+                ShowUsageOnEmptyCommandline = true
+            };
 
             argv = new CommandLineArguments();
 

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -5,6 +5,7 @@ namespace Divine
 {
     internal class Program
     {
+        // ReSharper disable once InconsistentNaming
         public static CommandLineArguments argv;
 
         private static void Main(string[] args)

--- a/Divine/Properties/AssemblyInfo.cs
+++ b/Divine/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Divine")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Divine")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cbfee38f-5f12-4d6f-b4fb-267fb68a6bea")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Divine/packages.config
+++ b/Divine/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
   <package id="CommandLineArgumentsParser" version="3.0.18" targetFramework="net46" />
 </packages>

--- a/Divine/packages.config
+++ b/Divine/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineArgumentsParser" version="3.0.18" targetFramework="net46" />
+</packages>

--- a/LSLib/LS/BinUtils.cs
+++ b/LSLib/LS/BinUtils.cs
@@ -1,36 +1,12 @@
 ﻿using zlib;
 using LZ4;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+using LSLib.LS.Enums;
 
 namespace LSLib.LS
 {
-    public enum CompressionMethod
-    {
-        None = 0,
-        Zlib = 1,
-        LZ4 = 2
-    };
-
-    public enum CompressionFlags
-    {
-        FastCompress = 0x10,
-        DefaultCompress = 0x20,
-        MaxCompressionLevel = 0x40
-    };
-
-    public enum CompressionLevel
-    {
-        FastCompression,
-        DefaultCompression,
-        MaxCompression
-    };
-
     static class BinUtils
     {
         public static T ReadStruct<T>(BinaryReader reader)

--- a/LSLib/LS/Common.cs
+++ b/LSLib/LS/Common.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/Enums/CompressionFlags.cs
+++ b/LSLib/LS/Enums/CompressionFlags.cs
@@ -1,0 +1,9 @@
+﻿namespace LSLib.LS.Enums
+{
+    public enum CompressionFlags
+    {
+        FastCompress = 0x10,
+        DefaultCompress = 0x20,
+        MaxCompressionLevel = 0x40
+    };
+}

--- a/LSLib/LS/Enums/CompressionLevel.cs
+++ b/LSLib/LS/Enums/CompressionLevel.cs
@@ -1,0 +1,9 @@
+﻿namespace LSLib.LS.Enums
+{
+    public enum CompressionLevel
+    {
+        FastCompression,
+        DefaultCompression,
+        MaxCompression
+    };
+}

--- a/LSLib/LS/Enums/CompressionMethod.cs
+++ b/LSLib/LS/Enums/CompressionMethod.cs
@@ -1,0 +1,9 @@
+﻿namespace LSLib.LS.Enums
+{
+    public enum CompressionMethod
+    {
+        None = 0,
+        Zlib = 1,
+        LZ4 = 2
+    };
+}

--- a/LSLib/LS/Enums/FileVersion.cs
+++ b/LSLib/LS/Enums/FileVersion.cs
@@ -1,0 +1,25 @@
+﻿namespace LSLib.LS.Enums
+{
+    public enum FileVersion
+    {
+        /// <summary>
+        /// Initial version of the LSF format
+        /// </summary>
+        VerInitial = 0x01,
+
+        /// <summary>
+        /// LSF version that added chunked compression for substreams
+        /// </summary>
+        VerChunkedCompress = 0x02,
+
+        /// <summary>
+        /// LSF version that extended the node descriptors
+        /// </summary>
+        VerExtendedNodes = 0x03,
+
+        /// <summary>
+        /// Latest version supported by this library
+        /// </summary>
+        CurrentVersion = 0x03
+    }
+}

--- a/LSLib/LS/Enums/Game.cs
+++ b/LSLib/LS/Enums/Game.cs
@@ -1,4 +1,4 @@
-﻿namespace Divine.Enums
+﻿namespace LSLib.LS.Enums
 {
     public enum Game
     {

--- a/LSLib/LS/Enums/ResourceFormat.cs
+++ b/LSLib/LS/Enums/ResourceFormat.cs
@@ -1,0 +1,10 @@
+﻿namespace LSLib.LS.Enums
+{
+    public enum ResourceFormat
+    {
+        LSX,
+        LSB,
+        LSF,
+        LSJ
+    };
+}

--- a/LSLib/LS/LSBReader.cs
+++ b/LSLib/LS/LSBReader.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/LSBWriter.cs
+++ b/LSLib/LS/LSBWriter.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/LSFWriter.cs
+++ b/LSLib/LS/LSFWriter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
+using LSLib.LS.Enums;
 
 namespace LSLib.LS.LSF
 {
@@ -31,10 +31,10 @@ namespace LSLib.LS.LSF
         private List<List<string>> StringHashMap;
         private bool ExtendedNodes = false;
 
-        public LSFWriter(Stream stream, UInt32 version)
+        public LSFWriter(Stream stream, FileVersion version)
         {
             this.Stream = stream;
-            this.Version = version;
+            this.Version = (uint) version;
         }
 
         public void Write(Resource resource)
@@ -81,7 +81,7 @@ namespace LSLib.LS.LSF
                     (resource.Metadata.revision << 8) |
                     resource.Metadata.buildNumber;
 
-                bool chunked = (header.Version >= FileVersion.VerChunkedCompress);
+                bool chunked = header.Version >= (ulong) FileVersion.VerChunkedCompress;
                 byte[] stringsCompressed = BinUtils.Compress(stringBuffer, Compression, CompressionLevel);
                 byte[] nodesCompressed = BinUtils.Compress(nodeBuffer, Compression, CompressionLevel, chunked);
                 byte[] attributesCompressed = BinUtils.Compress(attributeBuffer, Compression, CompressionLevel, chunked);
@@ -112,7 +112,7 @@ namespace LSLib.LS.LSF
         {
             foreach (var region in resource.Regions)
             {
-                if (Version >= FileVersion.VerExtendedNodes
+                if (Version >= (ulong) FileVersion.VerExtendedNodes
                     && ExtendedNodes)
                 {
                     WriteNodeV3(region.Value);
@@ -179,8 +179,7 @@ namespace LSLib.LS.LSF
             {
                 foreach (var child in children.Value)
                 {
-                    if (Version >= FileVersion.VerExtendedNodes
-                        && ExtendedNodes)
+                    if (Version >= (ulong) FileVersion.VerExtendedNodes && ExtendedNodes)
                     {
                         WriteNodeV3(child);
                     }

--- a/LSLib/LS/LSJResourceConverter.cs
+++ b/LSLib/LS/LSJResourceConverter.cs
@@ -9,10 +9,6 @@ namespace LSLib.LS
 {
     public class LSJResourceConverter : JsonConverter
     {
-        public LSJResourceConverter()
-        {
-        }
-
         public override bool CanConvert(Type objectType)
         {
             return objectType == typeof(Node)

--- a/LSLib/LS/LSJWriter.cs
+++ b/LSLib/LS/LSJWriter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Newtonsoft.Json;
 
 namespace LSLib.LS

--- a/LSLib/LS/LSXReader.cs
+++ b/LSLib/LS/LSXReader.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml;
 
 namespace LSLib.LS

--- a/LSLib/LS/LSXWriter.cs
+++ b/LSLib/LS/LSXWriter.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.IO;
 using System.Xml;
 
 namespace LSLib.LS

--- a/LSLib/LS/NodeAttribute.cs
+++ b/LSLib/LS/NodeAttribute.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/PackageCommon.cs
+++ b/LSLib/LS/PackageCommon.cs
@@ -1,12 +1,10 @@
-﻿using zlib;
-using LZ4;
-using LSLib.Granny;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using LSLib.LS.Enums;
 
 namespace LSLib.LS
 {
@@ -422,7 +420,7 @@ namespace LSLib.LS
                 writer.writeProgress += WriteProgressUpdate;
                 writer.Version = version;
                 writer.Compression = compression;
-                writer.CompressionLevel = fastCompression ? LS.CompressionLevel.FastCompression : LS.CompressionLevel.DefaultCompression;
+                writer.CompressionLevel = fastCompression ? CompressionLevel.FastCompression : CompressionLevel.DefaultCompression;
                 writer.Write();
             }
         }

--- a/LSLib/LS/PackageReader.cs
+++ b/LSLib/LS/PackageReader.cs
@@ -1,8 +1,5 @@
-﻿using zlib;
-using LZ4;
-using LSLib.Granny;
+﻿using LZ4;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/LSLib/LS/PackageWriter.cs
+++ b/LSLib/LS/PackageWriter.cs
@@ -1,6 +1,4 @@
-﻿using zlib;
-using LZ4;
-using LSLib.Granny;
+﻿using LZ4;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Security.Cryptography;
+using LSLib.LS.Enums;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/Resource.cs
+++ b/LSLib/LS/Resource.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace LSLib.LS
 {

--- a/LSLib/LS/ResourceUtils.cs
+++ b/LSLib/LS/ResourceUtils.cs
@@ -5,18 +5,10 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using LSLib.LS.Enums;
 
 namespace LSLib.LS
 {
-    public enum ResourceFormat
-    {
-        LSX,
-        LSB,
-        LSF,
-        LSJ
-    };
-
-
     public class ResourceUtils
     {
         public delegate void ProgressUpdateDelegate(string status, long numerator, long denominator);
@@ -97,7 +89,7 @@ namespace LSLib.LS
             SaveResource(resource, outputPath, ExtensionToResourceFormat(outputPath));
         }
 
-        public static void SaveResource(Resource resource, string outputPath, ResourceFormat format, int version = -1)
+        public static void SaveResource(Resource resource, string outputPath, ResourceFormat format, FileVersion version = 0x0)
         {
             FileManager.TryToCreateDirectory(outputPath);
 
@@ -122,16 +114,8 @@ namespace LSLib.LS
 
                     case ResourceFormat.LSF:
                         {
-                            uint lsfVersion;
-                            if (version == -1)
-                            {
-                                // Write in V2 format for D:OS EE compatibility
-                                lsfVersion = FileVersion.VerChunkedCompress;
-                            }
-                            else
-                            {
-                                lsfVersion = (uint)version;
-                            }
+                            // Write in V2 format for D:OS EE compatibility
+                            FileVersion lsfVersion = version == 0x0 ? FileVersion.VerChunkedCompress : version;
 
                             var writer = new LSFWriter(file, lsfVersion);
                             writer.Write(resource);
@@ -175,7 +159,7 @@ namespace LSLib.LS
             }
         }
 
-        public void ConvertResources(string inputDir, string outputDir, ResourceFormat inputFormat, ResourceFormat outputFormat, int outputVersion = -1)
+        public void ConvertResources(string inputDir, string outputDir, ResourceFormat inputFormat, ResourceFormat outputFormat, FileVersion outputVersion = 0x0)
         {
             this.progressUpdate("Enumerating files ...", 0, 1);
             var paths = new List<string>();

--- a/LSLib/LSLib.csproj
+++ b/LSLib/LSLib.csproj
@@ -141,7 +141,11 @@
     <Compile Include="Granny\Utils.cs" />
     <Compile Include="LS\BinUtils.cs" />
     <Compile Include="LS\Common.cs" />
+    <Compile Include="LS\Enums\CompressionLevel.cs" />
+    <Compile Include="LS\Enums\CompressionFlags.cs" />
+    <Compile Include="LS\Enums\CompressionMethod.cs" />
     <Compile Include="LS\FileManager.cs" />
+    <Compile Include="LS\Enums\FileVersion.cs" />
     <Compile Include="LS\LSBReader.cs" />
     <Compile Include="LS\LSBWriter.cs" />
     <Compile Include="LS\LSFReader.cs" />
@@ -157,6 +161,7 @@
     <Compile Include="LS\PackageWriter.cs" />
     <Compile Include="LS\PackageCommon.cs" />
     <Compile Include="LS\Resource.cs" />
+    <Compile Include="LS\Enums\ResourceFormat.cs" />
     <Compile Include="LS\ResourceUtils.cs" />
     <Compile Include="LS\Story\Adapter.cs" />
     <Compile Include="LS\Story\Call.cs" />

--- a/LSLib/LSLib.csproj
+++ b/LSLib/LSLib.csproj
@@ -144,6 +144,7 @@
     <Compile Include="LS\Enums\CompressionLevel.cs" />
     <Compile Include="LS\Enums\CompressionFlags.cs" />
     <Compile Include="LS\Enums\CompressionMethod.cs" />
+    <Compile Include="LS\Enums\Game.cs" />
     <Compile Include="LS\FileManager.cs" />
     <Compile Include="LS\Enums\FileVersion.cs" />
     <Compile Include="LS\LSBReader.cs" />

--- a/LSTools.sln
+++ b/LSTools.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConverterApp", "ConverterAp
 		{D8B26B12-E45C-47EA-88F7-56628EB2CCD1} = {D8B26B12-E45C-47EA-88F7-56628EB2CCD1}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Divine", "Divine\Divine.csproj", "{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,30 @@ Global
 		{FAD67294-6223-47E0-8838-E4E7FBC53ED2}.RelWithDebInfo|Win32.Build.0 = Release|Any CPU
 		{FAD67294-6223-47E0-8838-E4E7FBC53ED2}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{FAD67294-6223-47E0-8838-E4E7FBC53ED2}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|Win32.Build.0 = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Win32.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|Win32.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.Release|x64.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Mixed Platforms.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Win32.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|Win32.Build.0 = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{CBFEE38F-5F12-4D6F-B4FB-267FB68A6BEA}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Implemented CLI as Console Application project. (`AttachConsole(-1)` approach has issues, and standalone approach does not touch ConverterApp.)
- Uses NuGet package [CommandLineArgumentsParser](https://www.nuget.org/packages/CommandLineArgumentsParser/). Fluent is outdated, apparently abandoned, and some features appeared to be broken.
- Builds as "divine.exe"
- Requires absolute paths
- **Does not support OSI yet**
- Tested single/batch extraction of PAK files
- Tested single/batch conversion of LSJ, LSX, LSB, and LSF files
- **Did not test single/batch conversion of GR2 and DAE files**

# Example Commands

## Extract a single package
```
divine -a extract-package -s "E:\SteamLibrary\Divinity Original Sin 2\Data\Engine.pak" -d "E:\paks"
```

## Extract multiple packages
```
divine -a extract-packages -s "E:\SteamLibrary\Divinity Original Sin 2\Data" -d "E:\paks" --input-format pak
```

## Convert a single resource
```
divine -a convert-resource -s "E:\paks\Engine\Public\Engine\Content\[PAK]_Engine\1d2fa879-b4ac-417b-a221-ad72d65108f1.lsf" -d "E:\paks\Engine\Public\Engine\Content\[PAK]_Engine\1d2fa879-b4ac-417b-a221-ad72d65108f1.lsx"
```

## Convert multiple resources
```
divine -a convert-resources -s "E:\paks\Engine\Public\Engine\Content\[PAK]_Engine" -d "E:\paks\Engine\Public\Engine\Content\[PAK]_Engine" --input-format lsf --output-format lsx
```

