### PR TITLE
CLI Fixups

### DIFF
--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -115,6 +115,13 @@ namespace Divine.CLI
         )]
         public string ConformPath;
 
+        // @formatter:off
+        [SwitchArgument("use-package-name", false,
+            Description = "Use package name for destination folder",
+            Optional = true
+        )]
+        public bool UsePackageName;
+
         // @formatter:on
 
         public static LogLevel GetLogLevelByString(string logLevel)
@@ -181,9 +188,15 @@ namespace Divine.CLI
             }
         }
 
-        public static FileVersion GetFileVersionByGame(Game divinityGame) => divinityGame == LSLib.LS.Enums.Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+        public static FileVersion GetFileVersionByGame(Game divinityGame)
+        {
+            return divinityGame == LSLib.LS.Enums.Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+        }
 
-        public static ExportFormat GetExportFormatByString(string optionExportFormat) => optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
+        public static ExportFormat GetExportFormatByString(string optionExportFormat)
+        {
+            return optionExportFormat == "gr2" ? ExportFormat.GR2 : ExportFormat.DAE;
+        }
 
         // ReSharper disable once RedundantCaseLabel
         public static ResourceFormat GetResourceFormatByString(string resourceFormat)
@@ -238,7 +251,7 @@ namespace Divine.CLI
         public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion packageVersion)
         {
             CompressionMethod compression;
-            var fastCompression = true;
+            bool fastCompression = true;
 
             switch (compressionOption)
             {
@@ -284,7 +297,7 @@ namespace Divine.CLI
                 fastCompression = false;
             }
 
-            var compressionOptions = new Dictionary<string, object>
+            Dictionary<string, object> compressionOptions = new Dictionary<string, object>
             {
                 { "Compression", compression },
                 { "FastCompression", fastCompression }
@@ -295,7 +308,7 @@ namespace Divine.CLI
 
         public static Dictionary<string, bool> GetGR2Options(string[] options)
         {
-            var results = new Dictionary<string, bool>
+            Dictionary<string, bool> results = new Dictionary<string, bool>
             {
                 { "export-normals", false },
                 { "export-tangents", false },

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -20,8 +20,10 @@ namespace Divine.CLI
         {
             try
             {
+                ResourceFormat resourceFormat = ResourceUtils.ExtensionToResourceFormat(destinationPath);
+                CommandLineLogger.LogDebug($"Using destination extension: {resourceFormat}");
+
                 Resource resource = ResourceUtils.LoadResource(sourcePath);
-                ResourceFormat resourceFormat = ResourceUtils.ExtensionToResourceFormat(sourcePath);
 
                 ResourceUtils.SaveResource(resource, destinationPath, resourceFormat, fileVersion);
 
@@ -38,8 +40,9 @@ namespace Divine.CLI
         {
             try
             {
-                var resourceUtils = new ResourceUtils();
+                CommandLineLogger.LogDebug($"Using destination extension: {outputFormat}");
 
+                ResourceUtils resourceUtils = new ResourceUtils();
                 resourceUtils.ConvertResources(sourcePath, destinationPath, inputFormat, outputFormat, fileVersion);
 
                 CommandLineLogger.LogInfo($"Wrote resources to: {destinationPath}");

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -11,13 +11,19 @@ namespace Divine.CLI
     {
         private static readonly Dictionary<string, bool> GR2Options = CommandLineActions.GR2Options;
 
-        public static void Convert(string file = "") => ConvertResource(file);
+        public static void Convert(string file = "")
+        {
+            ConvertResource(file);
+        }
 
-        public static void BatchConvert() => BatchConvertResources(CommandLineActions.SourcePath, Program.argv.InputFormat);
+        public static void BatchConvert()
+        {
+            BatchConvertResources(CommandLineActions.SourcePath, Program.argv.InputFormat);
+        }
 
         public static ExporterOptions UpdateExporterSettings()
         {
-            var exporterOptions = new ExporterOptions
+            ExporterOptions exporterOptions = new ExporterOptions
             {
                 InputPath = CommandLineActions.SourcePath,
                 OutputPath = CommandLineActions.DestinationPath,
@@ -58,7 +64,7 @@ namespace Divine.CLI
 
         private static void ConvertResource(string file)
         {
-            var exporter = new Exporter
+            Exporter exporter = new Exporter
             {
                 Options = UpdateExporterSettings()
             };

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -7,13 +7,40 @@ namespace Divine.CLI
     {
         private static readonly LogLevel LogLevelOption = CommandLineActions.LogLevel;
 
-        public static void LogFatal(string message, int errorCode) => Log(LogLevel.FATAL, message, errorCode);
-        public static void LogError(string message) => Log(LogLevel.ERROR, message);
-        public static void LogWarn(string message) => Log(LogLevel.WARN, message);
-        public static void LogInfo(string message) => Log(LogLevel.INFO, message);
-        public static void LogDebug(string message) => Log(LogLevel.DEBUG, message);
-        public static void LogTrace(string message) => Log(LogLevel.TRACE, message);
-        public static void LogAll(string message) => Log(LogLevel.ALL, message);
+        public static void LogFatal(string message, int errorCode)
+        {
+            Log(LogLevel.FATAL, message, errorCode);
+        }
+
+        public static void LogError(string message)
+        {
+            Log(LogLevel.ERROR, message);
+        }
+
+        public static void LogWarn(string message)
+        {
+            Log(LogLevel.WARN, message);
+        }
+
+        public static void LogInfo(string message)
+        {
+            Log(LogLevel.INFO, message);
+        }
+
+        public static void LogDebug(string message)
+        {
+            Log(LogLevel.DEBUG, message);
+        }
+
+        public static void LogTrace(string message)
+        {
+            Log(LogLevel.TRACE, message);
+        }
+
+        public static void LogAll(string message)
+        {
+            Log(LogLevel.ALL, message);
+        }
 
         private static void Log(LogLevel logLevel, string message, int errorCode = -1)
         {

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -10,7 +10,7 @@ namespace Divine
 
         private static void Main(string[] args)
         {
-            var parser = new CommandLineParser.CommandLineParser
+            CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser
             {
                 IgnoreCase = true,
                 ShowUsageOnEmptyCommandline = true


### PR DESCRIPTION
- Resolved blocking issue that prevented conversion: files were duplicated instead of converted to other formats because the user-defined source path was passed to `ExtensionToResourceFormat`
- Set the extraction path to the user-defined destination path by default
- Added `--use-package-name` switch to replicate old behavior, where packages are extracted to respectively named folders in root of user-defined destination path
- Shared extraction path handling across single-file and batch operations
- Added more logging for Debug log level
- Improved code style consistency