### PR TITLE
NotAPackageException handling and extraction logging

### DIFF
--- a/Divine/CLI/CommandLinePackageProcessor.cs
+++ b/Divine/CLI/CommandLinePackageProcessor.cs
@@ -25,7 +25,7 @@ namespace Divine.CLI
             {
                 string extractionPath = GetExtractionPath(CommandLineActions.SourcePath, CommandLineActions.DestinationPath);
 
-                CommandLineLogger.LogDebug($"Extracting package: {CommandLineActions.SourcePath}");
+                CommandLineLogger.LogInfo($"Extracting package: {CommandLineActions.SourcePath}");
 
                 ExtractPackageResource(CommandLineActions.SourcePath, extractionPath);
             }
@@ -39,7 +39,7 @@ namespace Divine.CLI
             {
                 string extractionPath = GetExtractionPath(file, CommandLineActions.DestinationPath);
 
-                CommandLineLogger.LogDebug($"Extracting package: {file}");
+                CommandLineLogger.LogInfo($"Extracting package: {file}");
 
                 ExtractPackageResource(file, extractionPath);
             }
@@ -95,7 +95,7 @@ namespace Divine.CLI
             }
             catch (NotAPackageException)
             {
-                CommandLineLogger.LogFatal("Failed to extract package because the package is not an Original Sin package or savegame archive", 1);
+                CommandLineLogger.LogError("Failed to extract package because the package is not an Original Sin package or savegame archive");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- Don't exit on NotAPackageException during batch operations
- Show more logging during extraction

On a NotAPackageException during a batch operation, we should just continue on to the next package. I ran into this issue a lot because the _1, _2, _3, etc., packages are partial packages. It's okay to skip them because they were extracted previously during the batch operation, and by logging what was extracted by default, we know what's going on.