### PR TITLE
Fix setting ModelInfoFormat for the command line, added DOS2DE as a game enum

### DIFF
--- a/ConverterApp/GR2Pane.cs
+++ b/ConverterApp/GR2Pane.cs
@@ -230,28 +230,6 @@ namespace ConverterApp
         private void UpdateCommonExporterSettings(ExporterOptions settings)
         {
             Game game = _form.GetGame();
-            if (game == Game.DivinityOriginalSin)
-            {
-                settings.Is64Bit = false;
-                settings.AlternateSignature = false;
-                settings.VersionTag = Header.Tag_DOS;
-                settings.ModelInfoFormat = DivinityModelInfoFormat.None;
-            }
-            else
-            {
-                settings.Is64Bit = true;
-                settings.AlternateSignature = true;
-                settings.VersionTag = Header.Tag_DOSEE;
-
-                if (game == Game.DivinityOriginalSinEE)
-                {
-                    settings.ModelInfoFormat = DivinityModelInfoFormat.UserDefinedProperties;
-                }
-                else
-                {
-                    settings.ModelInfoFormat = DivinityModelInfoFormat.LSMv1;
-                }
-            }
 
             settings.ExportNormals = exportNormals.Checked;
             settings.ExportTangents = exportTangents.Checked;
@@ -269,6 +247,8 @@ namespace ConverterApp
             settings.UseObsoleteVersionTag = forceLegacyVersion.Checked;
             settings.FlipMesh = flipMeshes.Checked;
             settings.FlipSkeleton = flipSkeletons.Checked;
+
+			settings.LoadGameSettings(game);
 
             switch (gr2ExtraProps.SelectedIndex)
             {
@@ -337,7 +317,23 @@ namespace ConverterApp
             try
             {
                 exporter.Export();
-                MessageBox.Show("Export completed successfully.");
+
+				string optionsDebug = "Options: ";
+
+				var properties = typeof(ExporterOptions).GetFields();
+
+				foreach (var property in properties)
+				{
+					if (property != null)
+					{
+						object val = property.GetValue(exporter.Options);
+						optionsDebug += $"{property.Name}: {val}" + Environment.NewLine;
+					}
+				}
+
+				MessageBox.Show(optionsDebug);
+
+				//MessageBox.Show("Export completed successfully.");
             }
             catch (Exception exc)
             {

--- a/ConverterApp/GR2Pane.cs
+++ b/ConverterApp/GR2Pane.cs
@@ -318,22 +318,7 @@ namespace ConverterApp
             {
                 exporter.Export();
 
-				string optionsDebug = "Options: ";
-
-				var properties = typeof(ExporterOptions).GetFields();
-
-				foreach (var property in properties)
-				{
-					if (property != null)
-					{
-						object val = property.GetValue(exporter.Options);
-						optionsDebug += $"{property.Name}: {val}" + Environment.NewLine;
-					}
-				}
-
-				MessageBox.Show(optionsDebug);
-
-				//MessageBox.Show("Export completed successfully.");
+				MessageBox.Show("Export completed successfully.");
             }
             catch (Exception exc)
             {

--- a/ConverterApp/MainForm.Designer.cs
+++ b/ConverterApp/MainForm.Designer.cs
@@ -100,7 +100,8 @@
             this.gr2Game.Items.AddRange(new object[] {
             "Divinity: Original Sin (32-bit)",
             "Divinity: Original Sin EE (64-bit)",
-            "Divinity: Original Sin 2 and DE (64-bit)"});
+            "Divinity: Original Sin 2 (64-bit)",
+            "Divinity: Original Sin 2 DE (64-bit)"});
             this.gr2Game.Location = new System.Drawing.Point(74, 12);
             this.gr2Game.Name = "gr2Game";
             this.gr2Game.Size = new System.Drawing.Size(356, 21);

--- a/ConverterApp/MainForm.cs
+++ b/ConverterApp/MainForm.cs
@@ -42,7 +42,7 @@ namespace ConverterApp
             osirisTab.Controls.Add(osirisPane);
 
             Text += $" (LSLib v{Common.LibraryVersion()})";
-            gr2Game.SelectedIndex = 2;
+            gr2Game.SelectedIndex = gr2Game.Items.Count - 1;
         }
 
         public Game GetGame()
@@ -61,10 +61,10 @@ namespace ConverterApp
                 {
                     return Game.DivinityOriginalSin2;
                 }
-				case 3:
-				{
-					return Game.DivinityOriginalSin2DE;
-				}
+                case 3:
+                {
+                    return Game.DivinityOriginalSin2DE;
+                }
                 default:
                 {
                     throw new InvalidOperationException();
@@ -77,8 +77,8 @@ namespace ConverterApp
             Game game = GetGame();
             if (gr2Tab.Controls[0] is GR2Pane pane)
             {
-				pane.use16bitIndex.Checked = game == Game.DivinityOriginalSinEE || game.IsDOS2();
-				pane.flipMeshes.Checked = game.IsDOS2();
+                pane.use16bitIndex.Checked = game == Game.DivinityOriginalSinEE || game.IsDOS2();
+                pane.flipMeshes.Checked = game.IsDOS2();
             }
 
             packagePane.SetGame(game);

--- a/ConverterApp/MainForm.cs
+++ b/ConverterApp/MainForm.cs
@@ -61,6 +61,10 @@ namespace ConverterApp
                 {
                     return Game.DivinityOriginalSin2;
                 }
+				case 3:
+				{
+					return Game.DivinityOriginalSin2DE;
+				}
                 default:
                 {
                     throw new InvalidOperationException();
@@ -73,8 +77,8 @@ namespace ConverterApp
             Game game = GetGame();
             if (gr2Tab.Controls[0] is GR2Pane pane)
             {
-                pane.use16bitIndex.Checked = game == Game.DivinityOriginalSinEE || game == Game.DivinityOriginalSin2;
-                pane.flipMeshes.Checked = game == Game.DivinityOriginalSin2;
+				pane.use16bitIndex.Checked = game == Game.DivinityOriginalSinEE || game.IsDOS2();
+				pane.flipMeshes.Checked = game.IsDOS2();
             }
 
             packagePane.SetGame(game);

--- a/ConverterApp/PackagePane.cs
+++ b/ConverterApp/PackagePane.cs
@@ -91,21 +91,22 @@ namespace ConverterApp
                 switch (packageVersion.SelectedIndex)
                 {
                     case 0:
+                    case 1:
                     {
                         version = PackageVersion.V13;
                         break;
                     }
-                    case 1:
+                    case 2:
                     {
                         version = PackageVersion.V10;
                         break;
                     }
-                    case 2:
+                    case 3:
                     {
                         version = PackageVersion.V9;
                         break;
                     }
-                    case 3:
+                    case 4:
                     {
                         version = PackageVersion.V7;
                         break;
@@ -219,14 +220,17 @@ namespace ConverterApp
             switch (game)
             {
                 case Game.DivinityOriginalSin:
-                    packageVersion.SelectedIndex = 2;
+                    packageVersion.SelectedIndex = 3;
                     break;
 
                 case Game.DivinityOriginalSinEE:
-                    packageVersion.SelectedIndex = 1;
+                    packageVersion.SelectedIndex = 2;
                     break;
 
                 case Game.DivinityOriginalSin2:
+                    packageVersion.SelectedIndex = 1;
+                    break;
+                case Game.DivinityOriginalSin2DE:
                     packageVersion.SelectedIndex = 0;
                     break;
             }

--- a/ConverterApp/ResourcePane.cs
+++ b/ConverterApp/ResourcePane.cs
@@ -24,7 +24,7 @@ namespace ConverterApp
             {
                 _resource = ResourceUtils.LoadResource(resourceInputPath.Text);
                 ResourceFormat format = ResourceUtils.ExtensionToResourceFormat(resourceOutputPath.Text);
-                FileVersion outputVersion = _form.GetGame() == Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+                FileVersion outputVersion = _form.GetGame().IsDOS2() ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                 ResourceUtils.SaveResource(_resource, resourceOutputPath.Text, format, outputVersion);
 
                 MessageBox.Show("Resource saved successfully.");
@@ -120,7 +120,7 @@ namespace ConverterApp
                 case 2:
                 {
                     outputFormat = ResourceFormat.LSF;
-                    outputVersion = _form.GetGame() == Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+                    outputVersion = _form.GetGame().IsDOS2() ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
                     break;
                 }
                 case 3:

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -22,7 +22,7 @@ namespace Divine.CLI
         [EnumeratedValueArgument(typeof(string), 'g', "game",
             Description = "Set target game when generating output",
             DefaultValue = "dos2",
-            AllowedValues = "dos;dosee;dos2",
+            AllowedValues = "dos;dosee;dos2;dos2de",
             ValueOptional = false,
             Optional = true
         )]
@@ -193,17 +193,17 @@ namespace Divine.CLI
                 {
                     return LSLib.LS.Enums.Game.DivinityOriginalSin2;
                 }
-				case "dos2de":
-				default:
-				{
-					return LSLib.LS.Enums.Game.DivinityOriginalSin2DE;
-				}
+                case "dos2de":
+                default:
+                {
+                    return LSLib.LS.Enums.Game.DivinityOriginalSin2DE;
+                }
             }
         }
 
         public static FileVersion GetFileVersionByGame(Game divinityGame)
         {
-			return divinityGame.IsDOS2() ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+            return divinityGame.IsDOS2() ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
         }
 
         public static ExportFormat GetExportFormatByString(string optionExportFormat)

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -190,16 +190,20 @@ namespace Divine.CLI
                     return LSLib.LS.Enums.Game.DivinityOriginalSinEE;
                 }
                 case "dos2":
-                default:
                 {
                     return LSLib.LS.Enums.Game.DivinityOriginalSin2;
                 }
+				case "dos2de":
+				default:
+				{
+					return LSLib.LS.Enums.Game.DivinityOriginalSin2DE;
+				}
             }
         }
 
         public static FileVersion GetFileVersionByGame(Game divinityGame)
         {
-            return divinityGame == LSLib.LS.Enums.Game.DivinityOriginalSin2 ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
+			return divinityGame.IsDOS2() ? FileVersion.VerExtendedNodes : FileVersion.VerChunkedCompress;
         }
 
         public static ExportFormat GetExportFormatByString(string optionExportFormat)

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -23,7 +23,7 @@ namespace Divine.CLI
 
         public static ExporterOptions UpdateExporterSettings()
         {
-            ExporterOptions exporterOptions = new ExporterOptions
+            ExporterOptions exporterOptions = new ExporterOptions ()
             {
                 InputPath = CommandLineActions.SourcePath,
                 OutputPath = CommandLineActions.DestinationPath,
@@ -46,18 +46,7 @@ namespace Divine.CLI
                 ConformGR2Path = GR2Options["conform"] && !string.IsNullOrEmpty(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null
             };
 
-            if (CommandLineActions.Game == Game.DivinityOriginalSin)
-            {
-                exporterOptions.Is64Bit = false;
-                exporterOptions.AlternateSignature = false;
-                exporterOptions.VersionTag = Header.Tag_DOS;
-            }
-            else
-            {
-                exporterOptions.Is64Bit = true;
-                exporterOptions.AlternateSignature = true;
-                exporterOptions.VersionTag = Header.Tag_DOSEE;
-            }
+			exporterOptions.LoadGameSettings(CommandLineActions.Game);
 
             return exporterOptions;
         }
@@ -76,7 +65,23 @@ namespace Divine.CLI
 
             try
             {
+				string optionsDebug = "Options: ";
+
+				var properties = typeof(ExporterOptions).GetFields();
+
+				foreach (var property in properties)
+				{
+					if(property != null)
+					{
+						object val = property.GetValue(exporter.Options);
+						optionsDebug += $"{property.Name}: {val}" + Environment.NewLine;
+					}
+				}
+
+				CommandLineLogger.LogInfo(optionsDebug);
+
                 exporter.Export();
+
                 CommandLineLogger.LogInfo("Export completed successfully.");
             }
             catch (Exception e)

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -65,21 +65,6 @@ namespace Divine.CLI
 
             try
             {
-				string optionsDebug = "Options: ";
-
-				var properties = typeof(ExporterOptions).GetFields();
-
-				foreach (var property in properties)
-				{
-					if(property != null)
-					{
-						object val = property.GetValue(exporter.Options);
-						optionsDebug += $"{property.Name}: {val}" + Environment.NewLine;
-					}
-				}
-
-				CommandLineLogger.LogInfo(optionsDebug);
-
                 exporter.Export();
 
                 CommandLineLogger.LogInfo("Export completed successfully.");

--- a/LSLib/Granny/Model/Exporter.cs
+++ b/LSLib/Granny/Model/Exporter.cs
@@ -99,6 +99,38 @@ namespace LSLib.Granny.Model
         public bool FlipMesh = false;
         // Flip skeleton on X axis
         public bool FlipSkeleton = false;
+
+		public void LoadGameSettings(LSLib.LS.Enums.Game game)
+		{
+			switch (game)
+			{
+				case LSLib.LS.Enums.Game.DivinityOriginalSin:
+					Is64Bit = false;
+					AlternateSignature = false;
+					VersionTag = LSLib.Granny.GR2.Header.Tag_DOS;
+					ModelInfoFormat = DivinityModelInfoFormat.None;
+					break;
+				case LSLib.LS.Enums.Game.DivinityOriginalSinEE:
+					Is64Bit = true;
+					AlternateSignature = true;
+					VersionTag = LSLib.Granny.GR2.Header.Tag_DOSEE;
+					ModelInfoFormat = DivinityModelInfoFormat.UserDefinedProperties;
+					break;
+				case LSLib.LS.Enums.Game.DivinityOriginalSin2:
+					Is64Bit = true;
+					AlternateSignature = false;
+					VersionTag = LSLib.Granny.GR2.Header.Tag_DOSEE;
+					ModelInfoFormat = DivinityModelInfoFormat.LSMv1;
+					break;
+				case LSLib.LS.Enums.Game.DivinityOriginalSin2DE:
+				default:
+					Is64Bit = true;
+					AlternateSignature = false;
+					VersionTag = LSLib.Granny.GR2.Header.Tag_DOS2DE;
+					ModelInfoFormat = DivinityModelInfoFormat.LSMv1;
+					break;
+			}
+		}
     }
 
 

--- a/LSLib/LS/Enums/Game.cs
+++ b/LSLib/LS/Enums/Game.cs
@@ -4,6 +4,17 @@
     {
         DivinityOriginalSin = 0,
         DivinityOriginalSinEE = 1,
-        DivinityOriginalSin2 = 2
+		DivinityOriginalSin2 = 2,
+		DivinityOriginalSin2DE = 3,
     };
+
+	public static class GameEnumExtensions
+	{
+		public static bool IsDOS2(this Game game)
+		{
+			return (game == Game.DivinityOriginalSin2 || game == Game.DivinityOriginalSin2DE);
+		}
+	}
+	
+
 }


### PR DESCRIPTION
* CommandLineGR2Processor wasn't setting ModelInfoFormat  in the export settings when converting to gr2.
  * This was fixed by unifying applying game-related settings through the new LoadGameSettings function in ExporterOptions.
* DivinityOriginalSin2DE was added as an enum for supporting the DOS2DE header tag.
  * Spots where it check for DivinityOriginalSin2 should include DivinityOriginalSin2DE as well now.
  *  DOS2DE was added as a dropdown item in the ConverterApp.