### PR TITLE
Allow extracting and listing packages using expressions

### DIFF
--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -117,6 +117,15 @@ namespace Divine.CLI
         )]
         public string[] Options;
 
+		// @formatter:off
+		[ValueArgument(typeof(string), 'x', "expression",
+            Description = "Set glob expression for extract and list actions",
+            DefaultValue = "*",
+            ValueOptional = false,
+            Optional = true
+        )]
+        public string Expression;
+
         // @formatter:off
         [ValueArgument(typeof(string), "conform-path",
             Description = "Set conform to original path",
@@ -132,6 +141,13 @@ namespace Divine.CLI
             Optional = true
         )]
         public bool UsePackageName;
+
+		// @formatter:off
+        [SwitchArgument("use-regex", false,
+            Description = "Use Regular Expressions for expression type",
+            Optional = true
+        )]
+        public bool UseRegex;
 
         // @formatter:on
 
@@ -220,7 +236,7 @@ namespace Divine.CLI
 
         public static ExportFormat GetModelFormatByPath(string path)
         {
-            var extension = Path.GetExtension(path);
+            string extension = Path.GetExtension(path);
             if (extension != null)
             {
                 return GetModelFormatByString(extension.Substring(1));
@@ -284,7 +300,7 @@ namespace Divine.CLI
         public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion packageVersion)
         {
             CompressionMethod compression;
-            bool fastCompression = true;
+            var fastCompression = true;
 
             switch (compressionOption)
             {
@@ -330,7 +346,7 @@ namespace Divine.CLI
                 fastCompression = false;
             }
 
-            Dictionary<string, object> compressionOptions = new Dictionary<string, object>
+            var compressionOptions = new Dictionary<string, object>
             {
                 { "Compression", compression },
                 { "FastCompression", fastCompression }
@@ -341,7 +357,7 @@ namespace Divine.CLI
 
         public static Dictionary<string, bool> GetGR2Options(string[] options)
         {
-            Dictionary<string, bool> results = new Dictionary<string, bool>
+            var results = new Dictionary<string, bool>
             {
                 { "export-normals", true },
                 { "export-tangents", true },

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -42,7 +42,7 @@ namespace Divine.CLI
             {
                 CommandLineLogger.LogDebug($"Using destination extension: {outputFormat}");
 
-                ResourceUtils resourceUtils = new ResourceUtils();
+                var resourceUtils = new ResourceUtils();
                 resourceUtils.ConvertResources(sourcePath, destinationPath, inputFormat, outputFormat, fileVersion);
 
                 CommandLineLogger.LogInfo($"Wrote resources to: {destinationPath}");

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -23,7 +23,7 @@ namespace Divine.CLI
 
         public static ExporterOptions UpdateExporterSettings()
         {
-            ExporterOptions exporterOptions = new ExporterOptions ()
+            var exporterOptions = new ExporterOptions()
             {
                 InputPath = CommandLineActions.SourcePath,
                 OutputPath = CommandLineActions.DestinationPath,
@@ -66,7 +66,7 @@ namespace Divine.CLI
 
         private static void ConvertResource(string file)
         {
-            Exporter exporter = new Exporter
+            var exporter = new Exporter
             {
                 Options = UpdateExporterSettings()
             };

--- a/LSLib/LS/Common.cs
+++ b/LSLib/LS/Common.cs
@@ -1,19 +1,44 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace LSLib.LS
 {
-    public static class Common
-    {
-        public const int MajorVersion = 1;
-        public const int MinorVersion = 13;
-        public const int PatchVersion = 0;
+	public static class Common
+	{
+		public const int MajorVersion = 1;
 
-        /// <summary>
-        /// Returns the version number of the LSLib library
-        /// </summary>
-        public static string LibraryVersion()
-        {
-            return String.Format("{0}.{1}.{2}", MajorVersion, MinorVersion, PatchVersion);
-        }
-    }
+		public const int MinorVersion = 13;
+
+		public const int PatchVersion = 0;
+
+		/// <summary>
+		/// Returns the version number of the LSLib library
+		/// </summary>
+		public static string LibraryVersion()
+		{
+			return String.Format("{0}.{1}.{2}", MajorVersion, MinorVersion, PatchVersion);
+		}
+
+		/// <summary>
+		/// Compares the string against a given pattern.
+		/// </summary>
+		/// <param name="str">The string</param>
+		/// <param name="pattern">The pattern to match, where "*" means any sequence of characters, and "?" means any single character</param>
+		/// <returns><c>true</c> if the string matches the given pattern; otherwise <c>false</c>.</returns>
+		public static bool Like(this string str, string pattern)
+		{
+			return new Regex("^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$", RegexOptions.Singleline).IsMatch(str);
+		}
+
+		/// <summary>
+		/// Compares the string against a given pattern.
+		/// </summary>
+		/// <param name="str">The string</param>
+		/// <param name="pattern">The pattern to match as a RegEx object</param>
+		/// <returns><c>true</c> if the string matches the given pattern; otherwise <c>false</c>.</returns>
+		public static bool Like(this string str, Regex pattern)
+		{
+			return pattern.IsMatch(str);
+		}
+	}
 }


### PR DESCRIPTION
Allow extracting and listing packages using expressions

# Changes
- Added `-x`, `--expression` argument for glob and RegEx expressions
- Added `--use-regex` switch to enable RegEx expressions
- Order list-package action results alphanumerically
- Order files to extract by size in ascending order

# Usage
## Glob
```
divine -g dos2de -s "E:\SteamLibrary\Divinity Original Sin 2\DefEd\Data\Arena.pak" -a list-package -x "*.lsf"
divine -g dos2de -s "E:\SteamLibrary\Divinity Original Sin 2\DefEd\Data\Arena.pak" -a list-package -x "*Public*"
```
## RegEx
```
divine -g dos2de -a extract-packages -i pak -s "E:\SteamLibrary\Divinity Original Sin 2\DefEd\Data" -d "E:\DOS2_Repos\DefinitiveEdition" -x ".ls[f|b]$" --use-package-name --use-regex
```