### PR TITLE
Quick regex exception fix, TypeCoercionsWhitelist typo fix

### DIFF
--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -120,23 +120,35 @@ namespace Divine.CLI
 
         private static void Process(CommandLineArguments args)
         {
-	        var expression = new Regex("^" + Regex.Escape(args.Expression).Replace(@"\*", ".*").Replace(@"\?", ".") + "$", RegexOptions.Singleline | RegexOptions.Compiled);
+			Func<AbstractFileInfo, bool> filter;
 
-	        if (args.UseRegex)
-	        {
-		        try
-		        {
-			        expression = new Regex(args.Expression, RegexOptions.Singleline | RegexOptions.Compiled);
-		        }
-		        catch (ArgumentException)
-		        {
-			        CommandLineLogger.LogFatal($"Cannot parse RegEx expression: {args.Expression}", -1);
-		        }
-	        }
+			if (args.Expression != null)
+			{
+				Regex expression = null;
+				if (args.UseRegex)
+				{
+					try
+					{
+						expression = new Regex(args.Expression, RegexOptions.Singleline | RegexOptions.Compiled);
+					}
+					catch (ArgumentException)
+					{
+						CommandLineLogger.LogFatal($"Cannot parse RegEx expression: {args.Expression}", -1);
+					}
+				}
+				else
+				{
+					expression = new Regex("^" + Regex.Escape(args.Expression).Replace(@"\*", ".*").Replace(@"\?", ".") + "$", RegexOptions.Singleline | RegexOptions.Compiled);
+				}
 
-	        Func<AbstractFileInfo, bool> filter = obj => obj.Name.Like(expression);
+				filter = obj => obj.Name.Like(expression);
+			}
+			else
+			{
+				filter = obj => true;
+			}
 
-	        switch (args.Action)
+			switch (args.Action)
             {
                 case "create-package":
                 {

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -120,35 +120,35 @@ namespace Divine.CLI
 
         private static void Process(CommandLineArguments args)
         {
-			Func<AbstractFileInfo, bool> filter;
+            Func<AbstractFileInfo, bool> filter;
 
-			if (args.Expression != null)
-			{
-				Regex expression = null;
-				if (args.UseRegex)
-				{
-					try
-					{
-						expression = new Regex(args.Expression, RegexOptions.Singleline | RegexOptions.Compiled);
-					}
-					catch (ArgumentException)
-					{
-						CommandLineLogger.LogFatal($"Cannot parse RegEx expression: {args.Expression}", -1);
-					}
-				}
-				else
-				{
-					expression = new Regex("^" + Regex.Escape(args.Expression).Replace(@"\*", ".*").Replace(@"\?", ".") + "$", RegexOptions.Singleline | RegexOptions.Compiled);
-				}
+            if (args.Expression != null)
+            {
+                Regex expression = null;
+                if (args.UseRegex)
+                {
+                    try
+                    {
+                        expression = new Regex(args.Expression, RegexOptions.Singleline | RegexOptions.Compiled);
+                    }
+                    catch (ArgumentException)
+                    {
+                        CommandLineLogger.LogFatal($"Cannot parse RegEx expression: {args.Expression}", -1);
+                    }
+                }
+                else
+                {
+                    expression = new Regex("^" + Regex.Escape(args.Expression).Replace(@"\*", ".*").Replace(@"\?", ".") + "$", RegexOptions.Singleline | RegexOptions.Compiled);
+                }
 
-				filter = obj => obj.Name.Like(expression);
-			}
-			else
-			{
-				filter = obj => true;
-			}
+                filter = obj => obj.Name.Like(expression);
+            }
+            else
+            {
+                filter = obj => true;
+            }
 
-			switch (args.Action)
+            switch (args.Action)
             {
                 case "create-package":
                 {

--- a/LSLib/LS/Mods/ModResources.cs
+++ b/LSLib/LS/Mods/ModResources.cs
@@ -400,7 +400,7 @@ namespace LSLib.LS
                 }
 
                 var typeCoercionWhitelistPath = modPath + @"\Story\RawFiles\TypeCoercionWhitelist.txt";
-                if (File.Exists(headerPath))
+                if (File.Exists(typeCoercionWhitelistPath))
                 {
                     var fileInfo = new FilesystemFileInfo
                     {


### PR DESCRIPTION
The typeCoercionWhitelistPath check was checking headersPath instead, which then resulted in an exception when TypeCoercionWhitelist.txt wasn't found. Whoops!