### PR TITLE
Compatibility support for Granny models reporting as UInt8 instead of NormalUInt8

### DIFF
--- a/LSLib/Granny/Model/Vertex.cs
+++ b/LSLib/Granny/Model/Vertex.cs
@@ -503,6 +503,11 @@ namespace LSLib.Granny.Model
                         {
                             desc.ColorMapType = ColorMapType.Byte4;
                         }
+                        //Some Granny2 model formats report their color maps as UInt8 type instead of NormalUInt8, causing it to fail checks.
+                        else if (member.Type == MemberType.UInt8 && member.ArraySize == 4)
+                        {
+                            desc.ColorMapType = ColorMapType.Byte4;
+                        }
                         else
                         {
                             throw new Exception($"Unsupported color map type: {member.Type}, {member.ArraySize}");


### PR DESCRIPTION
Simple fix that also solves #34 

ES:O files report themselves as UInt8 instead of NormalUInt8 in the file header that causes them to fail the checks in the code. I've tested it and I was able to export ES:O models and import them into 3DS Max with no difficulty.