### PR TITLE
Optional recursion for batch conversion

### DIFF
--- a/ConverterApp/MainForm.Designer.cs
+++ b/ConverterApp/MainForm.Designer.cs
@@ -138,7 +138,7 @@
             this.Controls.Add(this.label7);
             this.Controls.Add(this.tabControl);
             this.Name = "MainForm";
-            this.Text = "GR2 Converter";
+            this.Text = "ConverterApp";
             this.tabControl.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/ConverterApp/ResourcePane.Designer.cs
+++ b/ConverterApp/ResourcePane.Designer.cs
@@ -49,6 +49,7 @@
             this.resourceOutputPath = new System.Windows.Forms.TextBox();
             this.label12 = new System.Windows.Forms.Label();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.cbRecurseIntoSubdirectories = new System.Windows.Forms.CheckBox();
             this.resourceProgressLabel = new System.Windows.Forms.Label();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.resourceInputFileDlg = new System.Windows.Forms.OpenFileDialog();
@@ -263,6 +264,7 @@
             // 
             this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox5.Controls.Add(this.cbRecurseIntoSubdirectories);
             this.groupBox5.Controls.Add(this.resourceProgressLabel);
             this.groupBox5.Controls.Add(this.resourceConversionProgress);
             this.groupBox5.Controls.Add(this.label17);
@@ -283,6 +285,16 @@
             this.groupBox5.TabIndex = 62;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "Batch Convert";
+            // 
+            // cbRecurseIntoSubdirectories
+            // 
+            this.cbRecurseIntoSubdirectories.AutoSize = true;
+            this.cbRecurseIntoSubdirectories.Location = new System.Drawing.Point(508, 137);
+            this.cbRecurseIntoSubdirectories.Name = "cbRecurseIntoSubdirectories";
+            this.cbRecurseIntoSubdirectories.Size = new System.Drawing.Size(154, 17);
+            this.cbRecurseIntoSubdirectories.TabIndex = 68;
+            this.cbRecurseIntoSubdirectories.Text = "Recurse into subdirectories";
+            this.cbRecurseIntoSubdirectories.UseVisualStyleBackColor = true;
             // 
             // resourceProgressLabel
             // 
@@ -365,5 +377,6 @@
         private System.Windows.Forms.SaveFileDialog resourceOutputFileDlg;
         private System.Windows.Forms.FolderBrowserDialog resourceInputPathDlg;
         private System.Windows.Forms.FolderBrowserDialog resourceOutputPathDlg;
+        private System.Windows.Forms.CheckBox cbRecurseIntoSubdirectories;
     }
 }

--- a/ConverterApp/ResourcePane.cs
+++ b/ConverterApp/ResourcePane.cs
@@ -145,6 +145,7 @@ namespace ConverterApp
                 resourceConvertBtn.Enabled = false;
                 var utils = new ResourceUtils();
                 utils.progressUpdate += ResourceProgressUpdate;
+                utils.NoRecurse = !cbRecurseIntoSubdirectories.Checked;
                 utils.ConvertResources(resourceInputDir.Text, resourceOutputDir.Text, inputFormat, outputFormat, outputVersion);
 
                 MessageBox.Show("Resources converted successfully.");

--- a/LSLib/LS/ResourceUtils.cs
+++ b/LSLib/LS/ResourceUtils.cs
@@ -11,29 +11,37 @@ namespace LSLib.LS
 {
     public class ResourceUtils
     {
+        public bool NoRecurse = false;
+
         public delegate void ProgressUpdateDelegate(string status, long numerator, long denominator);
         public ProgressUpdateDelegate progressUpdate = delegate { };
 
         public static ResourceFormat ExtensionToResourceFormat(string path)
         {
-            var extension = Path.GetExtension(path).ToLower();
+            var extension = Path.GetExtension(path).ToLowerInvariant();
 
             switch (extension)
             {
                 case ".lsx":
+                {
                     return ResourceFormat.LSX;
-
+                }
                 case ".lsb":
+                {
                     return ResourceFormat.LSB;
-
+                }
                 case ".lsf":
+                {
                     return ResourceFormat.LSF;
-
+                }
                 case ".lsj":
+                {
                     return ResourceFormat.LSJ;
-
+                }
                 default:
+                {
                     throw new ArgumentException("Unrecognized file extension: " + extension);
+                }
             }
         }
 
@@ -55,39 +63,37 @@ namespace LSLib.LS
             switch (format)
             {
                 case ResourceFormat.LSX:
+                {
+                    using (var reader = new LSXReader(stream))
                     {
-                        using (var reader = new LSXReader(stream))
-                        {
-                            return reader.Read();
-                        }
+                        return reader.Read();
                     }
-
+                }
                 case ResourceFormat.LSB:
+                {
+                    using (var reader = new LSBReader(stream))
                     {
-                        using (var reader = new LSBReader(stream))
-                        {
-                            return reader.Read();
-                        }
+                        return reader.Read();
                     }
-
+                }
                 case ResourceFormat.LSF:
+                {
+                    using (var reader = new LSFReader(stream))
                     {
-                        using (var reader = new LSFReader(stream))
-                        {
-                            return reader.Read();
-                        }
+                        return reader.Read();
                     }
-
+                }
                 case ResourceFormat.LSJ:
+                {
+                    using (var reader = new LSJReader(stream))
                     {
-                        using (var reader = new LSJReader(stream))
-                        {
-                            return reader.Read();
-                        }
+                        return reader.Read();
                     }
-
+                }
                 default:
+                {
                     throw new ArgumentException("Invalid resource format");
+                }
             }
         }
 
@@ -105,50 +111,53 @@ namespace LSLib.LS
                 switch (format)
                 {
                     case ResourceFormat.LSX:
-                        {
-                            var writer = new LSXWriter(file);
-                            writer.PrettyPrint = true;
-                            writer.Write(resource);
-                            break;
-                        }
-
+                    {
+                        var writer = new LSXWriter(file);
+                        writer.PrettyPrint = true;
+                        writer.Write(resource);
+                        break;
+                    }
                     case ResourceFormat.LSB:
-                        {
-                            var writer = new LSBWriter(file);
-                            writer.Write(resource);
-                            break;
-                        }
-
+                    {
+                        var writer = new LSBWriter(file);
+                        writer.Write(resource);
+                        break;
+                    }
                     case ResourceFormat.LSF:
-                        {
-                            // Write in V2 format for D:OS EE compatibility
-                            FileVersion lsfVersion = version == 0x0 ? FileVersion.VerChunkedCompress : version;
+                    {
+                        // Write in V2 format for D:OS EE compatibility
+                        FileVersion lsfVersion = version == 0x0 ? FileVersion.VerChunkedCompress : version;
 
-                            var writer = new LSFWriter(file, lsfVersion);
-                            writer.Write(resource);
-                            break;
-                        }
-
+                        var writer = new LSFWriter(file, lsfVersion);
+                        writer.Write(resource);
+                        break;
+                    }
                     case ResourceFormat.LSJ:
-                        {
-                            var writer = new LSJWriter(file);
-                            writer.PrettyPrint = true;
-                            writer.Write(resource);
-                            break;
-                        }
-
+                    {
+                        var writer = new LSJWriter(file);
+                        writer.PrettyPrint = true;
+                        writer.Write(resource);
+                        break;
+                    }
                     default:
+                    {
                         throw new ArgumentException("Invalid resource format");
+                    }
                 }
             }
         }
 
         private void EnumerateFiles(List<string> paths, string rootPath, string currentPath, string extension)
         {
+            if (string.IsNullOrWhiteSpace(currentPath) || !Directory.Exists(currentPath))
+            {
+                return;
+            }
+
             foreach (string filePath in Directory.GetFiles(currentPath))
             {
                 var fileExtension = Path.GetExtension(filePath);
-                if (fileExtension.ToLower() == extension)
+                if (!string.IsNullOrWhiteSpace(fileExtension) && fileExtension.ToLower() == extension)
                 {
                     var relativePath = filePath.Substring(rootPath.Length);
                     if (relativePath[0] == '/' || relativePath[0] == '\\')
@@ -158,6 +167,11 @@ namespace LSLib.LS
 
                     paths.Add(relativePath);
                 }
+            }
+
+            if (NoRecurse)
+            {
+                return;
             }
 
             foreach (string directoryPath in Directory.GetDirectories(currentPath))


### PR DESCRIPTION
- **Added "recurse into subdirectories" checkbox to resource pane for batch conversion**:<br>The default behavior was to always recurse into subdirectories, which is generally not what you want to do. A checkbox was added that allows you to toggle recursion. Also, this setting is nonpersistent between sessions because you don't want to unintentionally recurse into subdirectories after some time away.
- **Renamed main form to ConverterApp from GR2 Converter**:<br>Just seems weird to call the app "GR2 Converter" since lslib does a whole lot more.