### PR TITLE
Divine Fixes, BG3 Support, and Help Reformat

### DIFF
--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -80,7 +80,7 @@ namespace Divine.CLI
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'a', "action",
             Description = "Set action to execute",
-            DefaultValue = "extract-package",
+            DefaultValue = null,
             AllowedValues = "create-package;list-package;extract-single-file;extract-package;extract-packages;convert-model;convert-models;convert-resource;convert-resources",
             ValueOptional = false,
             Optional = false

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -12,7 +12,7 @@ namespace Divine.CLI
     {
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
-            Description = "Set verbosity level of log output",
+            Description = "Log output verbosity",
             DefaultValue = "info",
             AllowedValues = "off;fatal;error;warn;info;debug;trace;all",
             ValueOptional = false,
@@ -22,9 +22,9 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'g', "game",
-            Description = "Set target game when generating output",
+            Description = "Target game when generating output",
             DefaultValue = null,
-            AllowedValues = "dos;dosee;dos2;dos2de;bg3",
+            AllowedValues = "bg3;dos;dosee;dos2;dos2de",
             ValueOptional = false,
             Optional = false
         )]
@@ -32,7 +32,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [ValueArgument(typeof(string), 's', "source",
-            Description = "Set source file path or directory",
+            Description = "Source file path or directory",
             DefaultValue = null,
             ValueOptional = false,
             Optional = false
@@ -41,7 +41,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [ValueArgument(typeof(string), 'd', "destination",
-            Description = "Set destination file path or directory",
+            Description = "Destination file path or directory",
             DefaultValue = null,
             ValueOptional = true,
             Optional = true
@@ -59,7 +59,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'i', "input-format",
-            Description = "Set input format for batch operations",
+            Description = "Input format for batch operations",
             DefaultValue = null,
             AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
             ValueOptional = false,
@@ -69,7 +69,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'o', "output-format",
-            Description = "Set output format for batch operations",
+            Description = "Output format for batch operations",
             DefaultValue = null,
             AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
             ValueOptional = false,
@@ -79,7 +79,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'a', "action",
-            Description = "Set action to execute",
+            Description = "Action to execute",
             DefaultValue = null,
             AllowedValues = "create-package;list-package;extract-single-file;extract-package;extract-packages;convert-model;convert-models;convert-resource;convert-resources",
             ValueOptional = false,
@@ -89,7 +89,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'c', "compression-method",
-            Description = "Set compression method",
+            Description = "Compression method",
             DefaultValue = "lz4hc",
             AllowedValues = "zlib;zlibfast;lz4;lz4hc;none",
             ValueOptional = false,
@@ -99,7 +99,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'e', "gr2-options",
-            Description = "Set extra options for GR2/DAE conversion",
+            Description = "Extra options for GR2/DAE conversion",
             AllowMultiple = true,
             AllowedValues = "export-normals;export-tangents;export-uvs;export-colors;deduplicate-vertices;deduplicate-uvs;recalculate-normals;recalculate-tangents;recalculate-iwt;flip-uvs;ignore-uv-nan;y-up-skeletons;force-legacy-version;compact-tris;build-dummy-skeleton;apply-basis-transforms;x-flip-skeletons;x-flip-meshes;conform;conform-copy",
             ValueOptional = false,
@@ -109,7 +109,7 @@ namespace Divine.CLI
 
 		// @formatter:off
 		[ValueArgument(typeof(string), 'x', "expression",
-            Description = "Set glob expression for extract and list actions",
+            Description = "Glob expression for extract and list actions",
             DefaultValue = "*",
             ValueOptional = false,
             Optional = true
@@ -118,7 +118,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [ValueArgument(typeof(string), "conform-path",
-            Description = "Set conform to original path",
+            Description = "Conform to original path",
             DefaultValue = null,
             ValueOptional = false,
             Optional = true

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using LSLib.Granny.GR2;
 using LSLib.Granny.Model;
-using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {

--- a/Divine/CLI/DivineCommandLineParser.cs
+++ b/Divine/CLI/DivineCommandLineParser.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using CommandLineParser.Arguments;
+
+namespace Divine.CLI
+{
+    public class DivineCommandLineParser : CommandLineParser.CommandLineParser
+    {
+        private static string WordWrap(string text, int maxLength = 80, int indent = 0)
+        {
+            var indentation = "".PadLeft(indent);
+
+            var lineWrap = new Regex($"(.{{1,{maxLength}}})(?: +|$)");
+
+            return lineWrap.Replace(text, $"$1\n{indentation}");
+        }
+
+        private static void AddFormattedArgument(Argument argument, ICollection<string> list, string newline)
+        {
+            var line = string.Empty;
+
+            if (argument.ShortName.HasValue && !string.IsNullOrEmpty(argument.LongName))
+            {
+                line = $"  -{argument.ShortName}, --{argument.LongName}";
+            }
+            else if (argument.ShortName.HasValue)
+            {
+                line = $"  -{argument.ShortName}";
+            }
+            else if (!string.IsNullOrEmpty(argument.LongName))
+            {
+                line = $"  --{argument.LongName}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(line) && !string.IsNullOrWhiteSpace(argument.Description))
+            {
+                // manually adjust to: longest length of `line` + `offset` = 80
+                const int offset = 35;
+                list.Add(newline + line.PadRight(line.Length + Math.Abs(line.Length - offset)) + argument.Description);
+            }
+            else
+            {
+                list.Add(newline + line);
+            }
+
+            if (argument is EnumeratedValueArgument<string> enumValueArg)
+            {
+                if (!string.IsNullOrWhiteSpace(enumValueArg.DefaultValue))
+                {
+                    list.Add($"    Default Value:{newline}      {enumValueArg.DefaultValue}");
+                }
+
+                var allowedValues = string.Join(", ", enumValueArg.AllowedValues);
+                var formattedAllowedValues = WordWrap(allowedValues, 76, 6).TrimEnd();
+
+                list.Add($"    Allowed Values:{newline}      {formattedAllowedValues}");
+            }
+        }
+
+        public new void PrintUsage(TextWriter outputStream)
+        {
+            var lines = new List<string>();
+
+            var newline = outputStream.NewLine;
+
+            if (!string.IsNullOrWhiteSpace(ShowUsageHeader))
+            {
+                lines.Add("-------------------------------------------------------------------------------");
+                lines.Add(ShowUsageHeader);
+                lines.Add("-------------------------------------------------------------------------------");
+            }
+
+            lines.Add(newline + "required arguments:");
+
+            foreach (var argument in this.Arguments)
+            {
+                if (!argument.Optional)
+                {
+                    AddFormattedArgument(argument, lines, newline);
+                }
+            }
+
+            lines.Add(newline + "optional arguments:");
+
+            foreach (var argument in this.Arguments)
+            {
+                if (argument.Optional)
+                {
+                    AddFormattedArgument(argument, lines, newline);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(ShowUsageFooter))
+            {
+                lines.Add(ShowUsageFooter);
+            }
+
+            outputStream.Write(string.Join(newline, lines));
+            outputStream.WriteLine();
+        }
+    }
+}

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -57,6 +57,7 @@
     <Compile Include="CLI\CommandLineLogger.cs" />
     <Compile Include="CLI\CommandLinePackageProcessor.cs" />
     <Compile Include="CLI\CommandLineArguments.cs" />
+    <Compile Include="CLI\DivineCommandLineParser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Divine.CLI;
 
 namespace Divine
@@ -14,15 +15,29 @@ namespace Divine
             customCulture.NumberFormat.NumberDecimalSeparator = ".";
             System.Threading.Thread.CurrentThread.CurrentCulture = customCulture;
 
-            CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser
+            DivineCommandLineParser parser = new DivineCommandLineParser
             {
                 IgnoreCase = true,
-                ShowUsageOnEmptyCommandline = true
+                ShowUsageHeader = "Divine - by Norbyte & fireundubh <https://github.com/Norbyte/lslib>"
             };
 
             argv = new CommandLineArguments();
 
             parser.ExtractArgumentAttributes(argv);
+
+            string[] helpArgs =
+            {
+                @"-h",
+                @"--help",
+                @"-?",
+                @"/?"
+            };
+
+            if (args.Length == 0 || helpArgs.Any(args.Contains))
+            {
+                parser.PrintUsage(Console.Out);
+                return;
+            }
 
 #if !DEBUG
             try

--- a/Divine/Properties/AssemblyInfo.cs
+++ b/Divine/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 


### PR DESCRIPTION
# Notes

1. Please test. There are validation changes. I made these changes two months ago and haven't looked at this code since then.
2. You can modfy the usage header in `Program.cs` to whatever you want.

# Changes 

- Fixed issue where optional `-d` argument was inadvertently required by validation
- Fixed issue where CWD-relative paths were not passable argument values
- Fixed issue where required `-a` argument had default value
- Formatted help text output to show allowed arguments
- Added support for Baldur's Gate 3

# Help Reformat

```
-------------------------------------------------------------------------------
Divine - by Norbyte & fireundubh <https://github.com/Norbyte/lslib>
-------------------------------------------------------------------------------

required arguments:

  -g, --game                       Target game when generating output
    Allowed Values:
      bg3, dos, dosee, dos2, dos2de

  -s, --source                     Source file path or directory

  -a, --action                     Action to execute
    Allowed Values:
      create-package, list-package, extract-single-file, extract-package,
      extract-packages, convert-model, convert-models, convert-resource,
      convert-resources

optional arguments:

  -l, --loglevel                   Log output verbosity
    Default Value:
      info
    Allowed Values:
      off, fatal, error, warn, info, debug, trace, all

  -d, --destination                Destination file path or directory

  -f, --packaged-path              File to extract from package

  -i, --input-format               Input format for batch operations
    Allowed Values:
      dae, gr2, lsv, pak, lsj, lsx, lsb, lsf

  -o, --output-format              Output format for batch operations
    Allowed Values:
      dae, gr2, lsv, pak, lsj, lsx, lsb, lsf

  -c, --compression-method         Compression method
    Default Value:
      lz4hc
    Allowed Values:
      zlib, zlibfast, lz4, lz4hc, none

  -e, --gr2-options                Extra options for GR2/DAE conversion
    Allowed Values:
      export-normals, export-tangents, export-uvs, export-colors,
      deduplicate-vertices, deduplicate-uvs, recalculate-normals,
      recalculate-tangents, recalculate-iwt, flip-uvs, ignore-uv-nan,
      y-up-skeletons, force-legacy-version, compact-tris, build-dummy-skeleton,
      apply-basis-transforms, x-flip-skeletons, x-flip-meshes, conform,
      conform-copy

  -x, --expression                 Glob expression for extract and list actions

  --conform-path                   Conform to original path

  --use-package-name               Use package name for destination folder

  --use-regex                      Use Regular Expressions for expression type
```