### PR TITLE
Divine Enhancements and Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 _ReSharper.Caches/
 
 # Compiled Object files

--- a/Divine/App.config
+++ b/Divine/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
 </configuration>

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -76,10 +76,17 @@ namespace Divine.CLI
             {
                 if (!string.IsNullOrWhiteSpace(args.Destination))
                     DestinationPath = TryToValidatePath(args.Destination);
-                else if (PathUtils.IsDir(SourcePath))
-                    DestinationPath = SourcePath;
                 else
-                    DestinationPath = Path.GetDirectoryName(SourcePath);
+                {
+                    if (PathUtils.IsDir(SourcePath))
+                        DestinationPath = SourcePath;
+                    else
+                        DestinationPath = Path.GetDirectoryName(SourcePath);
+
+                    // do not require --destination argument for create-package action
+                    if (DestinationPath != null && string.Equals(args.Action, Constants.CREATE_PACKAGE, StringComparison.OrdinalIgnoreCase))
+                        DestinationPath += ".pak";
+                }
 
                 if (string.IsNullOrWhiteSpace(DestinationPath))
                     CommandLineLogger.LogFatal("Cannot proceed without a valid destination path", 1);

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -34,22 +34,22 @@ namespace Divine.CLI
         {
             string[] batchActions =
             {
-                "convert-models",
-                "convert-resources"
+                Constants.CONVERT_MODELS,
+                Constants.CONVERT_RESOURCES
             };
 
             string[] packageActionsWhereGameCanBeAutoDetected =
             {
-                "extract-package",
-                "extract-packages",
-                "extract-single-file",
-                "list-package"
+                Constants.EXTRACT_PACKAGE,
+                Constants.EXTRACT_PACKAGES,
+                Constants.EXTRACT_SINGLE_FILE,
+                Constants.LIST_PACKAGE
             };
 
             string[] graphicsActions =
             {
-                "convert-model",
-                "convert-models"
+                Constants.CONVERT_MODEL,
+                Constants.CONVERT_MODELS
             };
 
             LogLevel = CommandLineArguments.GetLogLevelByString(args.LogLevel);
@@ -58,7 +58,7 @@ namespace Divine.CLI
             // validate all source paths
             SourcePath = TryToValidatePath(args.Source);
 
-            if (string.Equals(args.Game, "autodetect", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(args.Game, Constants.AUTODETECT, StringComparison.OrdinalIgnoreCase))
             {
                 if (!packageActionsWhereGameCanBeAutoDetected.Any(args.Action.Contains))
                 {
@@ -90,14 +90,14 @@ namespace Divine.CLI
                 InputFormat = CommandLineArguments.GetResourceFormatByString(args.InputFormat);
                 CommandLineLogger.LogDebug($"Using input format: {InputFormat}");
 
-                if (!string.Equals(args.Action, "extract-packages", StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(args.Action, Constants.EXTRACT_PACKAGES, StringComparison.OrdinalIgnoreCase))
                 {
                     OutputFormat = CommandLineArguments.GetResourceFormatByString(args.OutputFormat);
                     CommandLineLogger.LogDebug($"Using output format: {OutputFormat}");
                 }
             }
 
-            if (string.Equals(args.Action, "create-package", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(args.Action, Constants.CREATE_PACKAGE, StringComparison.OrdinalIgnoreCase))
             {
                 PackageVersion = CommandLinePackageProcessor.GetPackageVersionByGame(Game);
             }
@@ -124,7 +124,9 @@ namespace Divine.CLI
             }
 
             // validate destination path for create-package action and batch actions
-            if (args.Action == "create-package" || args.Action == "extract-packages" || batchActions.Any(args.Action.Contains))
+            if (string.Equals(args.Action, Constants.CREATE_PACKAGE, StringComparison.OrdinalIgnoreCase) || 
+                string.Equals(args.Action, Constants.EXTRACT_PACKAGES, StringComparison.OrdinalIgnoreCase) ||
+                batchActions.Any(args.Action.Contains))
             {
                 if (string.IsNullOrWhiteSpace(args.Destination))
                 {
@@ -170,40 +172,40 @@ namespace Divine.CLI
 
             switch (args.Action)
             {
-                case "create-package":
+                case Constants.CREATE_PACKAGE:
                     CommandLinePackageProcessor.Create();
                     break;
 
-                case "extract-package":
+                case Constants.EXTRACT_PACKAGE:
                     CommandLinePackageProcessor.Extract(filter);
                     break;
 
-                case "extract-single-file":
+                case Constants.EXTRACT_SINGLE_FILE:
                     CommandLinePackageProcessor.ExtractSingleFile();
                     break;
 
-                case "list-package":
+                case Constants.LIST_PACKAGE:
                     CommandLinePackageProcessor.ListFiles(filter);
                     break;
 
-                case "convert-model":
+                case Constants.CONVERT_MODEL:
                     CommandLineGR2Processor.UpdateExporterSettings();
                     CommandLineGR2Processor.Convert();
                     break;
 
-                case "convert-resource":
+                case Constants.CONVERT_RESOURCE:
                     CommandLineDataProcessor.Convert();
                     break;
 
-                case "extract-packages":
+                case Constants.EXTRACT_PACKAGES:
                     CommandLinePackageProcessor.BatchExtract(filter);
                     break;
 
-                case "convert-models":
+                case Constants.CONVERT_MODELS:
                     CommandLineGR2Processor.BatchConvert();
                     break;
 
-                case "convert-resources":
+                case Constants.CONVERT_RESOURCES:
                     CommandLineDataProcessor.BatchConvert();
                     break;
 

--- a/Divine/CLI/CommandLineActions.cs
+++ b/Divine/CLI/CommandLineActions.cs
@@ -130,8 +130,7 @@ namespace Divine.CLI
             {
                 if (string.IsNullOrWhiteSpace(args.Destination))
                 {
-                    FileAttributes attrs = File.GetAttributes(SourcePath);
-                    DestinationPath = (attrs & FileAttributes.Directory) == FileAttributes.Directory ? SourcePath : Path.GetDirectoryName(SourcePath);
+                    DestinationPath = PathUtils.IsDir(SourcePath) ? SourcePath : Path.GetDirectoryName(SourcePath);
                 }
                 else
                 {

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -145,41 +145,23 @@ namespace Divine.CLI
             switch (logLevel)
             {
                 case "off":
-                {
                     return LSLib.LS.Enums.LogLevel.OFF;
-                }
                 case "fatal":
-                {
                     return LSLib.LS.Enums.LogLevel.FATAL;
-                }
                 case "error":
-                {
                     return LSLib.LS.Enums.LogLevel.ERROR;
-                }
                 case "warn":
-                {
                     return LSLib.LS.Enums.LogLevel.WARN;
-                }
                 case "info":
-                {
                     return LSLib.LS.Enums.LogLevel.INFO;
-                }
                 case "debug":
-                {
                     return LSLib.LS.Enums.LogLevel.DEBUG;
-                }
                 case "trace":
-                {
                     return LSLib.LS.Enums.LogLevel.TRACE;
-                }
                 case "all":
-                {
                     return LSLib.LS.Enums.LogLevel.ALL;
-                }
                 default:
-                {
                     return LSLib.LS.Enums.LogLevel.INFO;
-                }
             }
         }
 
@@ -189,29 +171,17 @@ namespace Divine.CLI
             switch (game)
             {
                 case "bg3":
-                {
                     return LSLib.LS.Enums.Game.BaldursGate3;
-                }
                 case "dos":
-                {
                     return LSLib.LS.Enums.Game.DivinityOriginalSin;
-                }
                 case "dosee":
-                {
                     return LSLib.LS.Enums.Game.DivinityOriginalSinEE;
-                }
                 case "dos2":
-                {
                     return LSLib.LS.Enums.Game.DivinityOriginalSin2;
-                }
                 case "dos2de":
-                {
                     return LSLib.LS.Enums.Game.DivinityOriginalSin2DE;
-                }
                 default:
-                {
                     throw new ArgumentException($"Unknown game: \"{game}\"");
-                }
             }
         }
 
@@ -220,17 +190,11 @@ namespace Divine.CLI
             switch (format.ToLower())
             {
                 case "gr2":
-                {
                     return ExportFormat.GR2;
-                }
                 case "dae":
-                {
                     return ExportFormat.DAE;
-                }
                 default:
-                {
                     throw new ArgumentException($"Unknown model format: {format}");
-                }
             }
         }
 
@@ -251,72 +215,50 @@ namespace Divine.CLI
             switch (resourceFormat)
             {
                 case "lsb":
-                {
                     return ResourceFormat.LSB;
-                }
                 case "lsf":
-                {
                     return ResourceFormat.LSF;
-                }
                 case "lsj":
-                {
                     return ResourceFormat.LSJ;
-                }
                 case "lsx":
-                {
                     return ResourceFormat.LSX;
-                }
                 default:
-                {
                     throw new ArgumentException($"Unknown resource format: \"{resourceFormat}\"");
-                }
             }
         }
 
         public static Dictionary<string, object> GetCompressionOptions(string compressionOption, PackageVersion packageVersion)
         {
             CompressionMethod compression;
-            var fastCompression = true;
+            bool fastCompression = true;
 
             switch (compressionOption)
             {
                 case "zlibfast":
-                {
                     compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                     break;
-                }
 
                 case "zlib":
-                {
                     compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                     fastCompression = false;
                     break;
-                }
 
                 case "lz4":
-                {
                     compression = LSLib.LS.Enums.CompressionMethod.LZ4;
                     break;
-                }
 
                 case "lz4hc":
-                {
                     compression = LSLib.LS.Enums.CompressionMethod.LZ4;
                     fastCompression = false;
                     break;
-                }
 
-                // ReSharper disable once RedundantCaseLabel
-                case "none":
                 default:
-                {
                     compression = LSLib.LS.Enums.CompressionMethod.None;
                     break;
-                }
             }
 
             // fallback to zlib, if the package version doesn't support lz4
-            if (compression == LSLib.LS.Enums.CompressionMethod.LZ4 && packageVersion <= LSLib.LS.Enums.PackageVersion.V9)
+            if (compression == LSLib.LS.Enums.CompressionMethod.LZ4 && packageVersion <= PackageVersion.V9)
             {
                 compression = LSLib.LS.Enums.CompressionMethod.Zlib;
                 fastCompression = false;

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -12,7 +12,7 @@ namespace Divine.CLI
     {
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'l', "loglevel",
-            Description = "Set verbosity level of log output",
+            Description = "Log output verbosity",
             DefaultValue = "info",
             AllowedValues = "off;fatal;error;warn;info;debug;trace;all",
             ValueOptional = false,
@@ -22,17 +22,17 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'g', "game",
-            Description = "Set target game when generating output",
-            DefaultValue = null,
-            AllowedValues = "dos;dosee;dos2;dos2de;bg3",
+            Description = "Target game when generating output",
+            DefaultValue = "autodetect",
+            AllowedValues = "dos;dosee;dos2;dos2de;bg3;autodetect",
             ValueOptional = false,
-            Optional = false
+            Optional = true
         )]
         public string Game;
 
         // @formatter:off
         [ValueArgument(typeof(string), 's', "source",
-            Description = "Set source file path or directory",
+            Description = "Source file path or directory",
             DefaultValue = null,
             ValueOptional = false,
             Optional = false
@@ -41,7 +41,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [ValueArgument(typeof(string), 'd', "destination",
-            Description = "Set destination file path or directory",
+            Description = "Destination file path or directory",
             DefaultValue = null,
             ValueOptional = true,
             Optional = true
@@ -59,9 +59,9 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'i', "input-format",
-            Description = "Set input format for batch operations",
+            Description = "Input format for batch operations",
             DefaultValue = null,
-            AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
+            AllowedValues = "dae;gr2;lsv;lsj;lsx;lsb;lsf",
             ValueOptional = false,
             Optional = true
         )]
@@ -69,9 +69,9 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'o', "output-format",
-            Description = "Set output format for batch operations",
+            Description = "Output format for batch operations",
             DefaultValue = null,
-            AllowedValues = "dae;gr2;lsv;pak;lsj;lsx;lsb;lsf",
+            AllowedValues = "dae;gr2;lsv;lsj;lsx;lsb;lsf",
             ValueOptional = false,
             Optional = true
         )]
@@ -79,8 +79,8 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'a', "action",
-            Description = "Set action to execute",
-            DefaultValue = "extract-package",
+            Description = "Action to execute",
+            DefaultValue = null,
             AllowedValues = "create-package;list-package;extract-single-file;extract-package;extract-packages;convert-model;convert-models;convert-resource;convert-resources",
             ValueOptional = false,
             Optional = false
@@ -89,7 +89,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'c', "compression-method",
-            Description = "Set compression method",
+            Description = "Compression method",
             DefaultValue = "lz4hc",
             AllowedValues = "zlib;zlibfast;lz4;lz4hc;none",
             ValueOptional = false,
@@ -99,7 +99,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [EnumeratedValueArgument(typeof(string), 'e', "gr2-options",
-            Description = "Set extra options for GR2/DAE conversion",
+            Description = "Extra options for GR2/DAE conversion",
             AllowMultiple = true,
             AllowedValues = "export-normals;export-tangents;export-uvs;export-colors;deduplicate-vertices;deduplicate-uvs;recalculate-normals;recalculate-tangents;recalculate-iwt;flip-uvs;ignore-uv-nan;y-up-skeletons;force-legacy-version;compact-tris;build-dummy-skeleton;apply-basis-transforms;x-flip-skeletons;x-flip-meshes;conform;conform-copy",
             ValueOptional = false,
@@ -109,7 +109,7 @@ namespace Divine.CLI
 
 		// @formatter:off
 		[ValueArgument(typeof(string), 'x', "expression",
-            Description = "Set glob expression for extract and list actions",
+            Description = "Glob expression for extract and list actions",
             DefaultValue = "*",
             ValueOptional = false,
             Optional = true
@@ -118,7 +118,7 @@ namespace Divine.CLI
 
         // @formatter:off
         [ValueArgument(typeof(string), "conform-path",
-            Description = "Set conform to original path",
+            Description = "Conform to original path",
             DefaultValue = null,
             ValueOptional = false,
             Optional = true

--- a/Divine/CLI/CommandLineArguments.cs
+++ b/Divine/CLI/CommandLineArguments.cs
@@ -187,7 +187,7 @@ namespace Divine.CLI
 
         public static ExportFormat GetModelFormatByString(string format)
         {
-            switch (format.ToLower())
+            switch (format.ToLowerInvariant())
             {
                 case "gr2":
                     return ExportFormat.GR2;

--- a/Divine/CLI/CommandLineDataProcessor.cs
+++ b/Divine/CLI/CommandLineDataProcessor.cs
@@ -4,17 +4,17 @@ using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
-    internal class CommandLineDataProcessor
+    internal static class CommandLineDataProcessor
     {
         public static void Convert()
         {
-            var conversionParams = ResourceConversionParameters.FromGameVersion(CommandLineActions.Game);
+            ResourceConversionParameters conversionParams = ResourceConversionParameters.FromGameVersion(CommandLineActions.Game);
             ConvertResource(CommandLineActions.SourcePath, CommandLineActions.DestinationPath, conversionParams);
         }
 
         public static void BatchConvert()
         {
-            var conversionParams = ResourceConversionParameters.FromGameVersion(CommandLineActions.Game);
+            ResourceConversionParameters conversionParams = ResourceConversionParameters.FromGameVersion(CommandLineActions.Game);
             BatchConvertResource(CommandLineActions.SourcePath, CommandLineActions.DestinationPath, CommandLineActions.InputFormat, CommandLineActions.OutputFormat, conversionParams);
         }
 

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -1,25 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using LSLib.Granny.GR2;
 using LSLib.Granny.Model;
-using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
-    internal class CommandLineGR2Processor
+    internal static class CommandLineGR2Processor
     {
         private static readonly Dictionary<string, bool> GR2Options = CommandLineActions.GR2Options;
 
-        public static void Convert(string file = "")
-        {
-            ConvertResource(file);
-        }
+        public static void Convert(string file = "") => ConvertResource(file);
 
-        public static void BatchConvert()
-        {
-            BatchConvertResources(CommandLineActions.SourcePath, Program.argv.InputFormat);
-        }
+        public static void BatchConvert() => BatchConvertResources(CommandLineActions.SourcePath, Program.argv.InputFormat);
 
         public static ExporterOptions UpdateExporterSettings()
         {
@@ -43,7 +35,7 @@ namespace Divine.CLI
                 DeduplicateUVs = GR2Options["deduplicate-uvs"],
                 ApplyBasisTransforms = GR2Options["apply-basis-transforms"],
                 UseObsoleteVersionTag = GR2Options["force-legacy-version"],
-                ConformGR2Path = GR2Options["conform"] && !string.IsNullOrEmpty(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null,
+                ConformGR2Path = GR2Options["conform"] && !string.IsNullOrWhiteSpace(CommandLineActions.ConformPath) ? CommandLineActions.ConformPath : null,
                 FlipSkeleton = GR2Options["x-flip-skeletons"],
                 FlipMesh = GR2Options["x-flip-meshes"],
                 TransformSkeletons = GR2Options["y-up-skeletons"],
@@ -71,7 +63,7 @@ namespace Divine.CLI
                 Options = UpdateExporterSettings()
             };
 
-            if (!string.IsNullOrEmpty(file))
+            if (!string.IsNullOrWhiteSpace(file))
             {
                 exporter.Options.InputPath = file;
             }

--- a/Divine/CLI/CommandLineGR2Processor.cs
+++ b/Divine/CLI/CommandLineGR2Processor.cs
@@ -84,7 +84,7 @@ namespace Divine.CLI
 
                 CommandLineLogger.LogInfo("Export completed successfully.");
 #if !DEBUG
-        }
+            }
             catch (Exception e)
             {
                 CommandLineLogger.LogFatal($"Export failed: {e.Message + Environment.NewLine + e.StackTrace}", 2);

--- a/Divine/CLI/CommandLineLogger.cs
+++ b/Divine/CLI/CommandLineLogger.cs
@@ -3,44 +3,23 @@ using LSLib.LS.Enums;
 
 namespace Divine.CLI
 {
-    internal class CommandLineLogger
+    internal static class CommandLineLogger
     {
         private static readonly LogLevel LogLevelOption = CommandLineActions.LogLevel;
 
-        public static void LogFatal(string message, int errorCode)
-        {
-            Log(LogLevel.FATAL, message, errorCode);
-        }
+        public static void LogFatal(string message, int errorCode) => Log(LogLevel.FATAL, message, errorCode);
 
-        public static void LogError(string message)
-        {
-            Log(LogLevel.ERROR, message);
-        }
+        public static void LogError(string message) => Log(LogLevel.ERROR, message);
 
-        public static void LogWarn(string message)
-        {
-            Log(LogLevel.WARN, message);
-        }
+        public static void LogWarn(string message) => Log(LogLevel.WARN, message);
 
-        public static void LogInfo(string message)
-        {
-            Log(LogLevel.INFO, message);
-        }
+        public static void LogInfo(string message) => Log(LogLevel.INFO, message);
 
-        public static void LogDebug(string message)
-        {
-            Log(LogLevel.DEBUG, message);
-        }
+        public static void LogDebug(string message) => Log(LogLevel.DEBUG, message);
 
-        public static void LogTrace(string message)
-        {
-            Log(LogLevel.TRACE, message);
-        }
+        public static void LogTrace(string message) => Log(LogLevel.TRACE, message);
 
-        public static void LogAll(string message)
-        {
-            Log(LogLevel.ALL, message);
-        }
+        public static void LogAll(string message) => Log(LogLevel.ALL, message);
 
         private static void Log(LogLevel logLevel, string message, int errorCode = -1)
         {
@@ -52,72 +31,67 @@ namespace Divine.CLI
             switch (logLevel)
             {
                 case LogLevel.FATAL:
-                {
                     if (LogLevelOption > LogLevel.OFF)
                     {
                         Console.WriteLine($"[FATAL] {message}");
                     }
 
-                    if (errorCode == -1)
+                    switch (errorCode)
                     {
-                        Environment.Exit((int) LogLevel.FATAL);
+                        case -1:
+                            Environment.Exit((int)LogLevel.FATAL);
+                            break;
+                        default:
+                            Environment.Exit((int)LogLevel.FATAL + errorCode);
+                            break;
                     }
-                    else
-                    {
-                        Environment.Exit((int) LogLevel.FATAL + errorCode);
-                    }
+
                     break;
-                }
 
                 case LogLevel.ERROR:
-                {
                     if (LogLevelOption < logLevel)
                     {
                         break;
                     }
+
                     Console.WriteLine($"[ERROR] {message}");
                     break;
-                }
 
                 case LogLevel.WARN:
-                {
                     if (LogLevelOption < logLevel)
                     {
                         break;
                     }
+
                     Console.WriteLine($"[WARN] {message}");
                     break;
-                }
 
                 case LogLevel.INFO:
-                {
                     if (LogLevelOption < logLevel)
                     {
                         break;
                     }
+
                     Console.WriteLine($"[INFO] {message}");
                     break;
-                }
 
                 case LogLevel.DEBUG:
-                {
                     if (LogLevelOption < logLevel)
                     {
                         break;
                     }
+
                     Console.WriteLine($"[DEBUG] {message}");
                     break;
-                }
 
                 case LogLevel.TRACE:
-                {
                     if (LogLevelOption < logLevel)
                     {
                         break;
                     }
+
                     Console.WriteLine($"[TRACE] {message}");
                     break;
-                }
             }
         }
     }

--- a/Divine/CLI/CommandLinePackageProcessor.cs
+++ b/Divine/CLI/CommandLinePackageProcessor.cs
@@ -27,7 +27,7 @@ namespace Divine.CLI
 
         private static void ExtractSingleFile(string packagePath, string destinationPath, string packagedPath)
         {
-            if (string.Equals(Args.Game, "autodetect", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Args.Game, Constants.AUTODETECT, StringComparison.OrdinalIgnoreCase))
             {
                 CommandLineActions.Game = GetGameByPackageVersion(packagePath);
             }
@@ -78,7 +78,7 @@ namespace Divine.CLI
 
         private static void ListPackageFiles(string packagePath, Func<AbstractFileInfo, bool> filter = null)
         {
-            if (string.Equals(Args.Game, "autodetect", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Args.Game, Constants.AUTODETECT, StringComparison.OrdinalIgnoreCase))
             {
                 CommandLineActions.Game = GetGameByPackageVersion(packagePath);
             }
@@ -132,7 +132,7 @@ namespace Divine.CLI
         {
             string[] files;
             
-            if (string.Equals(Args.Action, "extract-packages", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Args.Action, Constants.EXTRACT_PACKAGES, StringComparison.OrdinalIgnoreCase))
             {
                 files = Directory.GetFiles(CommandLineActions.SourcePath, "*.pak");
             }
@@ -204,7 +204,7 @@ namespace Divine.CLI
                 CommandLineLogger.LogDebug($"Using source path: {file}");
             }
             
-            if (string.Equals(Args.Game, "autodetect", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Args.Game, Constants.AUTODETECT, StringComparison.OrdinalIgnoreCase))
             {
                 CommandLineActions.Game = GetGameByPackageVersion(file);
             }

--- a/Divine/CLI/DivineCommandLineParser.cs
+++ b/Divine/CLI/DivineCommandLineParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using CommandLineParser.Arguments;
 
@@ -10,7 +11,7 @@ namespace Divine.CLI
     {
         private static string WordWrap(string text, int maxLength = 80, int indent = 0)
         {
-            var indentation = "".PadLeft(indent);
+            string indentation = "".PadLeft(indent);
 
             var lineWrap = new Regex($"(.{{1,{maxLength}}})(?: +|$)");
 
@@ -19,9 +20,9 @@ namespace Divine.CLI
 
         private static void AddFormattedArgument(Argument argument, ICollection<string> list, string newline)
         {
-            var line = string.Empty;
+            string line = string.Empty;
 
-            if (argument.ShortName.HasValue && !string.IsNullOrEmpty(argument.LongName))
+            if (argument.ShortName.HasValue && !string.IsNullOrWhiteSpace(argument.LongName))
             {
                 line = $"  -{argument.ShortName}, --{argument.LongName}";
             }
@@ -29,7 +30,7 @@ namespace Divine.CLI
             {
                 line = $"  -{argument.ShortName}";
             }
-            else if (!string.IsNullOrEmpty(argument.LongName))
+            else if (!string.IsNullOrWhiteSpace(argument.LongName))
             {
                 line = $"  --{argument.LongName}";
             }
@@ -52,8 +53,8 @@ namespace Divine.CLI
                     list.Add($"    Default Value:{newline}      {enumValueArg.DefaultValue}");
                 }
 
-                var allowedValues = string.Join(", ", enumValueArg.AllowedValues);
-                var formattedAllowedValues = WordWrap(allowedValues, 76, 6).TrimEnd();
+                string allowedValues = string.Join(", ", enumValueArg.AllowedValues);
+                string formattedAllowedValues = WordWrap(allowedValues, 76, 6).TrimEnd();
 
                 list.Add($"    Allowed Values:{newline}      {formattedAllowedValues}");
             }
@@ -63,7 +64,7 @@ namespace Divine.CLI
         {
             var lines = new List<string>();
 
-            var newline = outputStream.NewLine;
+            string newline = outputStream.NewLine;
 
             if (!string.IsNullOrWhiteSpace(ShowUsageHeader))
             {
@@ -74,22 +75,16 @@ namespace Divine.CLI
 
             lines.Add(newline + "required arguments:");
 
-            foreach (var argument in this.Arguments)
+            foreach (var argument in Arguments.Where(argument => !argument.Optional))
             {
-                if (!argument.Optional)
-                {
-                    AddFormattedArgument(argument, lines, newline);
-                }
+                AddFormattedArgument(argument, lines, newline);
             }
 
             lines.Add(newline + "optional arguments:");
 
-            foreach (var argument in this.Arguments)
+            foreach (var argument in Arguments.Where(argument => argument.Optional))
             {
-                if (argument.Optional)
-                {
-                    AddFormattedArgument(argument, lines, newline);
-                }
+                AddFormattedArgument(argument, lines, newline);
             }
 
             if (!string.IsNullOrWhiteSpace(ShowUsageFooter))

--- a/Divine/CLI/DivineCommandLineParser.cs
+++ b/Divine/CLI/DivineCommandLineParser.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+using CommandLineParser.Arguments;
+
+namespace Divine.CLI
+{
+    public class DivineCommandLineParser : CommandLineParser.CommandLineParser
+    {
+        private static string WordWrap(string text, int maxLength = 80, int indent = 0)
+        {
+            var indentation = "".PadLeft(indent);
+
+            var lineWrap = new Regex($"(.{{1,{maxLength}}})(?: +|$)");
+
+            return lineWrap.Replace(text, $"$1\n{indentation}");
+        }
+
+        private static void AddFormattedArgument(Argument argument, ICollection<string> list, string newline)
+        {
+            var line = string.Empty;
+
+            if (argument.ShortName.HasValue && !string.IsNullOrEmpty(argument.LongName))
+            {
+                line = $"  -{argument.ShortName}, --{argument.LongName}";
+            }
+            else if (argument.ShortName.HasValue)
+            {
+                line = $"  -{argument.ShortName}";
+            }
+            else if (!string.IsNullOrEmpty(argument.LongName))
+            {
+                line = $"  --{argument.LongName}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(line) && !string.IsNullOrWhiteSpace(argument.Description))
+            {
+                // manually adjust to: longest length of `line` + `offset` = 80
+                const int offset = 35;
+                list.Add(newline + line.PadRight(line.Length + Math.Abs(line.Length - offset)) + argument.Description);
+            }
+            else
+            {
+                list.Add(newline + line);
+            }
+
+            if (argument is EnumeratedValueArgument<string> enumValueArg)
+            {
+                if (!string.IsNullOrWhiteSpace(enumValueArg.DefaultValue))
+                {
+                    list.Add($"    Default Value:{newline}      {enumValueArg.DefaultValue}");
+                }
+
+                var allowedValues = string.Join(", ", enumValueArg.AllowedValues);
+                var formattedAllowedValues = WordWrap(allowedValues, 76, 6).TrimEnd();
+
+                list.Add($"    Allowed Values:{newline}      {formattedAllowedValues}");
+            }
+        }
+
+        public new void PrintUsage(TextWriter outputStream)
+        {
+            var lines = new List<string>();
+
+            var newline = outputStream.NewLine;
+
+            if (!string.IsNullOrWhiteSpace(ShowUsageHeader))
+            {
+                lines.Add("-------------------------------------------------------------------------------");
+                lines.Add(ShowUsageHeader);
+                lines.Add("-------------------------------------------------------------------------------");
+            }
+
+            lines.Add(newline + "required arguments:");
+
+            foreach (var argument in this.Arguments)
+            {
+                if (!argument.Optional)
+                {
+                    AddFormattedArgument(argument, lines, newline);
+                }
+            }
+
+            lines.Add(newline + "optional arguments:");
+
+            foreach (var argument in this.Arguments)
+            {
+                if (argument.Optional)
+                {
+                    AddFormattedArgument(argument, lines, newline);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(ShowUsageFooter))
+            {
+                lines.Add(ShowUsageFooter);
+            }
+
+            outputStream.Write(string.Join(newline, lines));
+            outputStream.WriteLine();
+        }
+    }
+}

--- a/Divine/Constants.cs
+++ b/Divine/Constants.cs
@@ -1,0 +1,16 @@
+namespace Divine
+{
+    public static class Constants
+    {
+        public const string AUTODETECT = "autodetect";
+        public const string CONVERT_MODEL = "convert-model";
+        public const string CONVERT_MODELS = "convert-models";
+        public const string CONVERT_RESOURCE = "convert-resource";
+        public const string CONVERT_RESOURCES = "convert-resources";
+        public const string CREATE_PACKAGE = "create-package";
+        public const string EXTRACT_PACKAGE = "extract-package";
+        public const string EXTRACT_PACKAGES = "extract-packages";
+        public const string EXTRACT_SINGLE_FILE = "extract-single-file";
+        public const string LIST_PACKAGE = "list-package";
+    }
+}

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -9,10 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Divine</RootNamespace>
     <AssemblyName>divine</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -33,10 +35,11 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLineArgumentsParser, Version=3.0.19.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommandLineArgumentsParser.3.0.19\lib\net452\CommandLineArgumentsParser.dll</HintPath>
+    <Reference Include="CommandLineArgumentsParser, Version=3.0.22.0, Culture=neutral, PublicKeyToken=2990a79b704d8378, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineArgumentsParser.3.0.22\lib\net452\CommandLineArgumentsParser.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -35,9 +35,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AlphaFS, Version=2.2.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
-      <HintPath>..\packages\AlphaFS.2.2.6\lib\net452\AlphaFS.dll</HintPath>
-    </Reference>
     <Reference Include="CommandLineArgumentsParser, Version=3.0.19.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\CommandLineArgumentsParser.3.0.19\lib\net452\CommandLineArgumentsParser.dll</HintPath>
     </Reference>

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -57,6 +57,7 @@
     <Compile Include="CLI\CommandLineLogger.cs" />
     <Compile Include="CLI\CommandLinePackageProcessor.cs" />
     <Compile Include="CLI\CommandLineArguments.cs" />
+    <Compile Include="CLI\DivineCommandLineParser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -58,6 +58,7 @@
     <Compile Include="CLI\CommandLinePackageProcessor.cs" />
     <Compile Include="CLI\CommandLineArguments.cs" />
     <Compile Include="CLI\DivineCommandLineParser.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Divine/Divine.csproj
+++ b/Divine/Divine.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PathUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Divine/PathUtils.cs
+++ b/Divine/PathUtils.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+
+namespace Divine
+{
+    public static class PathUtils
+    {
+        public static bool IsDir(string path)
+        {
+            FileAttributes attr;
+            
+            try
+            {
+                attr = File.GetAttributes(path);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return attr.HasFlag(FileAttributes.Directory);
+        }
+
+        public static bool IsFile(string path)
+        {
+            FileAttributes attr;
+            
+            try
+            {
+                attr = File.GetAttributes(path);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return !attr.HasFlag(FileAttributes.Directory);
+        }
+    }
+}

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -30,6 +30,7 @@ namespace Divine
             {
                 @"-h",
                 @"--help",
+                @"help",
                 @"-?",
                 @"/?"
             };
@@ -42,7 +43,7 @@ namespace Divine
 
             if (args.Length == 1)
             {
-                var path = args[0];
+                string path = args[0];
 
                 if (Directory.Exists(path))
                 {

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
 using Divine.CLI;
 
 namespace Divine
@@ -14,15 +16,61 @@ namespace Divine
             customCulture.NumberFormat.NumberDecimalSeparator = ".";
             System.Threading.Thread.CurrentThread.CurrentCulture = customCulture;
 
-            CommandLineParser.CommandLineParser parser = new CommandLineParser.CommandLineParser
+            DivineCommandLineParser parser = new DivineCommandLineParser
             {
                 IgnoreCase = true,
-                ShowUsageOnEmptyCommandline = true
+                ShowUsageHeader = "Divine <https://github.com/Norbyte/lslib>"
             };
 
             argv = new CommandLineArguments();
 
             parser.ExtractArgumentAttributes(argv);
+            
+            string[] helpArgs =
+            {
+                @"-h",
+                @"--help",
+                @"-?",
+                @"/?"
+            };
+
+            if (args.Length == 0 || helpArgs.Any(args.Contains))
+            {
+                parser.PrintUsage(Console.Out);
+                return;
+            }
+
+            if (args.Length == 1)
+            {
+                var path = args[0];
+
+                if (Directory.Exists(path))
+                {
+                    args = new[]
+                    {
+#if DEBUG
+                        "-l", "all",
+#endif
+                        "-a", "extract-packages",
+                        "-s", $"{path}",
+                        "-d", $"{path}",
+                        "--use-package-name"
+                    };
+                }
+                else if (File.Exists(path))
+                {
+                    args = new[]
+                    {
+#if DEBUG
+                        "-l", "all",
+#endif
+                        "-a", "extract-package",
+                        "-s", $"{path}",
+                        "-d", $"{Path.GetDirectoryName(path)}",
+                        "--use-package-name"
+                    };
+                }
+            }
 
 #if !DEBUG
             try

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -52,7 +52,7 @@ namespace Divine
 #if DEBUG
                         "-l", "all",
 #endif
-                        "-a", "extract-packages",
+                        "-a", Constants.EXTRACT_PACKAGES,
                         "-s", $"{path}",
                         "-d", $"{path}",
                         "--use-package-name"
@@ -65,7 +65,7 @@ namespace Divine
 #if DEBUG
                         "-l", "all",
 #endif
-                        "-a", "extract-package",
+                        "-a", Constants.EXTRACT_PACKAGE,
                         "-s", $"{path}",
                         "-d", $"{Path.GetDirectoryName(path)}",
                         "--use-package-name"

--- a/Divine/Program.cs
+++ b/Divine/Program.cs
@@ -44,8 +44,8 @@ namespace Divine
             if (args.Length == 1)
             {
                 string path = args[0];
-
-                if (Directory.Exists(path))
+                
+                if (PathUtils.IsDir(path))
                 {
                     args = new[]
                     {
@@ -58,7 +58,7 @@ namespace Divine
                         "--use-package-name"
                     };
                 }
-                else if (File.Exists(path))
+                else if (PathUtils.IsFile(path))
                 {
                     args = new[]
                     {

--- a/Divine/Properties/AssemblyInfo.cs
+++ b/Divine/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Divine/packages.config
+++ b/Divine/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AlphaFS" version="2.2.6" targetFramework="net462" />
   <package id="CommandLineArgumentsParser" version="3.0.19" targetFramework="net462" />
 </packages>

--- a/Divine/packages.config
+++ b/Divine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineArgumentsParser" version="3.0.19" targetFramework="net462" />
+  <package id="CommandLineArgumentsParser" version="3.0.22" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
I worked a bit on Divine today, primarily to implement the new features/behaviors under Changes.

I didn't squash the second commit so you can more clearly see the first's differences.

# Changes

- Implemented game autodetection for `--extract-package`, `--extract-packages`, `--extract-single-file`, and `--list-package`
- Implemented drag-and-drop support for single and batch package extraction
- Implemented relative path handling for `--source` and `--destination` arguments
- Set `--game` argument to optional
- Set `--game` argument value to `"autodetect"` by default
- Removed invalid format `"pak"` as allowed value for `--input-format` and `--output-format` arguments
- Formatted help text output to show allowed arguments
- Added `"help"` to valid help argument values
- Refactoring, reformatting, and cleanup

# Fixes

- Fixed issue where CWD-relative paths were not passable argument values
- Fixed issue where validation required optional `--destination` argument
- Fixed issue where required `--action` argument had default value
- Fixed issue where some fields were not populated with argument values
- Fixed issue where `--extract-packages` caused validation failure expecting invalid resource format
- Fixed issue where `--use-package-name` caused validation failure when destination path not explicitly set
- Fixed issue where relative `--source` path caused validation failure
- Fixed issue where `.` and `..` were not expanded in relative destination paths
