### PR TITLE
Fix BG3 savegame export (error code 101)

### DIFF
--- a/ConverterApp/OsirisPane.cs
+++ b/ConverterApp/OsirisPane.cs
@@ -194,7 +194,7 @@ namespace ConverterApp
 
             // Re-package global.lsf
             var rewrittenPackage = new Package();
-            StreamFileInfo globalsRepacked = StreamFileInfo.CreateFromStream(rewrittenStream, "globals.lsf");
+            StreamFileInfo globalsRepacked = StreamFileInfo.CreateFromStream(rewrittenStream, "Globals.lsf");
             rewrittenPackage.Files.Add(globalsRepacked);
 
             List<AbstractFileInfo> files = package.Files.Where(x => x.Name.ToLowerInvariant() != "globals.lsf").ToList();


### PR DESCRIPTION
Loading an exported BG3 savegame in v4.1.1.3622274 throws an error in game:

![Screenshot 2023-08-03 215745](https://github.com/Norbyte/lslib/assets/117625/be35ca8a-a691-4b92-8726-3b1e147430a3)

Unpacking an working savegame reveals the globals are saved in a file named `Globals.lsf`, but the OsirisPane currently exports this file as `globals.lsf`. After changing this filename, modified savegames load in BG3.

*Disclaimer: I am not sure if previous versions depend on this file being lowercase.*