### PR TITLE
Enable X-flip export options for DAE

### DIFF
--- a/LSLib/Granny/Model/Exporter.cs
+++ b/LSLib/Granny/Model/Exporter.cs
@@ -758,8 +758,7 @@ namespace LSLib.Granny.Model
                 GenerateDummySkeleton(Root);
             }
 
-            if (Options.OutputFormat == ExportFormat.GR2 &&
-                (Options.FlipMesh || Options.FlipSkeleton))
+            if (Options.FlipMesh || Options.FlipSkeleton)
             {
                 Root.Flip(Options.FlipMesh, Options.FlipSkeleton);
             }

--- a/LSLib/Granny/Model/Skeleton.cs
+++ b/LSLib/Granny/Model/Skeleton.cs
@@ -221,17 +221,9 @@ namespace LSLib.Granny.Model
 
         public void Flip()
         {
-            foreach (var bone in Bones)
+            foreach (var bone in Bones) if (bone.IsRoot)
             {
-                if (bone.IsRoot)
-                {
-                    bone.Transform.Flags |= (uint)Transform.TransformFlags.HasScaleShear;
-                    bone.Transform.ScaleShear = new Matrix3(
-                        -1.0f, 0.0f, 0.0f,
-                        0.0f, 1.0f, 0.0f,
-                        0.0f, 0.0f, 1.0f
-                    );
-                }
+               bone.Transform.SetScale(new Vector3(-1, 1, 1));
             }
 
             UpdateWorldTransforms();

--- a/LSLib/LSLib.csproj
+++ b/LSLib/LSLib.csproj
@@ -60,8 +60,20 @@
       <HintPath>..\external\gppg\binaries\QUT.ShiftReduceParser.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/LSLib/packages.config
+++ b/LSLib/packages.config
@@ -3,5 +3,9 @@
   <package id="AlphaFS" version="2.2.6" targetFramework="net462" />
   <package id="lz4net" version="1.0.15.93" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
   <package id="zlib.net" version="1.0.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Fixes #47 by enabling the "X-flip meshes" and "X-flip skeleton" options when exporting from .gr2 to .dae
- Changes `Skeleton.Flip()` to preserve the relative positions and angles of bones in the skeleton
- Requires the System.Memory package in order to update `Deduplicator<T>` structs via `Span<T>`