### PR TITLE
Added ability to load single .gtp file streams into memory

### DIFF
--- a/LSLib/VirtualTextures/PageFile.cs
+++ b/LSLib/VirtualTextures/PageFile.cs
@@ -13,7 +13,7 @@ namespace LSLib.VirtualTextures
         private const UInt32 PageSize = 0x100000;
 
         private VirtualTileSet TileSet;
-        private FileStream Stream;
+        private Stream Stream;
         private BinaryReader Reader;
         public GTPHeader Header;
         private List<UInt32[]> ChunkOffsets;
@@ -21,7 +21,7 @@ namespace LSLib.VirtualTextures
         public PageFile(VirtualTileSet tileset, string path)
         {
             TileSet = tileset;
-            Stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            Stream = new MemoryStream();
             Reader = new BinaryReader(Stream);
 
             Header = BinUtils.ReadStruct<GTPHeader>(Reader);
@@ -37,6 +37,11 @@ namespace LSLib.VirtualTextures
                 ChunkOffsets.Add(offsets);
 
                 Stream.Position = (page + 1) * PageSize;
+            }
+
+            if(File.Exists(path))
+            {
+                Stream.CopyTo(new FileStream(path, FileMode.Open, FileAccess.Read));
             }
         }
 

--- a/LSLib/VirtualTextures/PageFile.cs
+++ b/LSLib/VirtualTextures/PageFile.cs
@@ -13,7 +13,7 @@ namespace LSLib.VirtualTextures
         private const UInt32 PageSize = 0x100000;
 
         private VirtualTileSet TileSet;
-        private FileStream Stream;
+        private MemoryStream Stream;
         private BinaryReader Reader;
         public GTPHeader Header;
         private List<UInt32[]> ChunkOffsets;
@@ -21,7 +21,21 @@ namespace LSLib.VirtualTextures
         public PageFile(VirtualTileSet tileset, string path)
         {
             TileSet = tileset;
-            Stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            fileStream.CopyTo(Stream);
+            fileStream.Dispose();
+            Setup();
+        }
+
+        public PageFile(VirtualTileSet tileset, byte[] data)
+        {
+            TileSet = tileset;
+            Stream = new MemoryStream(data);
+            Setup();
+        }
+
+        private void Setup()
+        {
             Reader = new BinaryReader(Stream);
 
             Header = BinUtils.ReadStruct<GTPHeader>(Reader);

--- a/LSLib/VirtualTextures/PageFile.cs
+++ b/LSLib/VirtualTextures/PageFile.cs
@@ -13,7 +13,7 @@ namespace LSLib.VirtualTextures
         private const UInt32 PageSize = 0x100000;
 
         private VirtualTileSet TileSet;
-        private Stream Stream;
+        private FileStream Stream;
         private BinaryReader Reader;
         public GTPHeader Header;
         private List<UInt32[]> ChunkOffsets;
@@ -21,7 +21,7 @@ namespace LSLib.VirtualTextures
         public PageFile(VirtualTileSet tileset, string path)
         {
             TileSet = tileset;
-            Stream = new MemoryStream();
+            Stream = new FileStream(path, FileMode.Open, FileAccess.Read);
             Reader = new BinaryReader(Stream);
 
             Header = BinUtils.ReadStruct<GTPHeader>(Reader);
@@ -37,11 +37,6 @@ namespace LSLib.VirtualTextures
                 ChunkOffsets.Add(offsets);
 
                 Stream.Position = (page + 1) * PageSize;
-            }
-
-            if(File.Exists(path))
-            {
-                Stream.CopyTo(new FileStream(path, FileMode.Open, FileAccess.Read));
             }
         }
 

--- a/LSLib/VirtualTextures/PageFile.cs
+++ b/LSLib/VirtualTextures/PageFile.cs
@@ -21,9 +21,8 @@ namespace LSLib.VirtualTextures
         public PageFile(VirtualTileSet tileset, string path)
         {
             TileSet = tileset;
-            var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
-            fileStream.CopyTo(Stream);
-            fileStream.Dispose();
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
+                fileStream.CopyTo(Stream);
             Setup();
         }
 

--- a/LSLib/VirtualTextures/PageFile.cs
+++ b/LSLib/VirtualTextures/PageFile.cs
@@ -21,8 +21,10 @@ namespace LSLib.VirtualTextures
         public PageFile(VirtualTileSet tileset, string path)
         {
             TileSet = tileset;
+            Stream = new MemoryStream();
             using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
                 fileStream.CopyTo(Stream);
+            Stream.Position = 0;
             Setup();
         }
 

--- a/LSLib/VirtualTextures/VirtualTexture.cs
+++ b/LSLib/VirtualTextures/VirtualTexture.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace LSLib.VirtualTextures
 {
@@ -59,6 +57,14 @@ namespace LSLib.VirtualTextures
             using (var reader = new BinaryReader(fs))
             {
                 LoadFromStream(fs, reader, false);
+            }
+        }
+
+        public VirtualTileSet(Stream stream)
+        {
+            using (var reader = new BinaryReader(stream))
+            {
+                LoadFromStream(stream, reader, false);
             }
         }
 

--- a/LSLib/VirtualTextures/VirtualTexture.cs
+++ b/LSLib/VirtualTextures/VirtualTexture.cs
@@ -504,20 +504,20 @@ namespace LSLib.VirtualTextures
             }
         }
 
-        public PageFile GetOrLoadPageFile(int pageFileIdx)
+        public PageFile GetOrLoadPageFile(int pageFileIdx, byte[] data = null)
         {
             PageFile file;
             if (!PageFiles.TryGetValue(pageFileIdx, out file))
             {
                 var meta = PageFileInfos[pageFileIdx];
-                file = new PageFile(this, PagePath + Path.DirectorySeparatorChar + meta.Name);
+                file = PagePath != null ? new PageFile(this, PagePath + Path.DirectorySeparatorChar + meta.Name) : new PageFile(this, data);
                 PageFiles.Add(pageFileIdx, file);
             }
 
             return file;
         }
 
-        public void StitchTexture(int level, int layer, int minX, int minY, int maxX, int maxY, BC5Image output)
+        public void StitchTexture(int level, int layer, int minX, int minY, int maxX, int maxY, BC5Image output, byte[] data = null)
         {
             var tileWidth = Header.TileWidth - Header.TileBorder * 2;
             var tileHeight = Header.TileHeight - Header.TileBorder * 2;
@@ -528,7 +528,7 @@ namespace LSLib.VirtualTextures
                 {
                     if (GetTileInfo(level, layer, x, y, ref tileInfo))
                     {
-                        var pageFile = GetOrLoadPageFile(tileInfo.PageFileIndex);
+                        var pageFile = GetOrLoadPageFile(tileInfo.PageFileIndex, data);
                         var tile = pageFile.UnpackTileBC5(tileInfo.PageIndex, tileInfo.ChunkIndex);
                         tile.CopyTo(output, 8, 8, (x - minX) * tileWidth, (y - minY) * tileHeight, tileWidth, tileHeight);
                     }
@@ -536,12 +536,12 @@ namespace LSLib.VirtualTextures
             }
         }
 
-        public BC5Image ExtractTexture(int level, int layer, int minX, int minY, int maxX, int maxY)
+        public BC5Image ExtractTexture(int level, int layer, int minX, int minY, int maxX, int maxY, byte[] data = null)
         {
             var width = (maxX - minX + 1) * (Header.TileWidth - Header.TileBorder * 2);
             var height = (maxY - minY + 1) * (Header.TileHeight - Header.TileBorder * 2);
             var stitched = new BC5Image(width, height);
-            StitchTexture(level, layer, minX, minY, maxX, maxY, stitched);
+            StitchTexture(level, layer, minX, minY, maxX, maxY, stitched, data);
             return stitched;
         }
 
@@ -563,7 +563,7 @@ namespace LSLib.VirtualTextures
             this.PageFiles.Clear();
         }
 
-        public BC5Image ExtractPageFileTexture(int pageFileIndex, int levelIndex, int layer)
+        public BC5Image ExtractPageFileTexture(int pageFileIndex, int levelIndex, int layer, byte[] data = null)
         {
             int minX = 0, maxX = 0, minY = 0, maxY = 0;
             bool foundPages = false;
@@ -605,7 +605,7 @@ namespace LSLib.VirtualTextures
             }
             else
             {
-                return ExtractTexture(levelIndex, layer, minX, minY, maxX, maxY);
+                return ExtractTexture(levelIndex, layer, minX, minY, maxX, maxY, data);
             }
         }
     }

--- a/LSLib/VirtualTextures/VirtualTexture.cs
+++ b/LSLib/VirtualTextures/VirtualTexture.cs
@@ -511,7 +511,7 @@ namespace LSLib.VirtualTextures
             if (!PageFiles.TryGetValue(pageFileIdx, out file))
             {
                 var meta = PageFileInfos[pageFileIdx];
-                file = PagePath != null ? new PageFile(this, PagePath + Path.DirectorySeparatorChar + meta.Name) : new PageFile(this, SingleFileContents);
+                file = SingleFileContents == null ? new PageFile(this, PagePath + Path.DirectorySeparatorChar + meta.Name) : new PageFile(this, SingleFileContents);
                 PageFiles.Add(pageFileIdx, file);
             }
 
@@ -564,9 +564,8 @@ namespace LSLib.VirtualTextures
             this.PageFiles.Clear();
         }
 
-        public BC5Image ExtractPageFileTexture(int pageFileIndex, int levelIndex, int layer, byte[] data = null)
+        public BC5Image ExtractPageFileTexture(int pageFileIndex, int levelIndex, int layer)
         {
-            SingleFileContents = data;
             int minX = 0, maxX = 0, minY = 0, maxY = 0;
             bool foundPages = false;
 


### PR DESCRIPTION
This change is necessary for the multitool to use virtual textures without unpacking and decompressing the .gts files.

I have tested to make sure the original functionality still works as intended.