### PR TITLE
Fix weight normalization so total is always 255

### DIFF
--- a/LSLib/Granny/Model/ColladaImporter.cs
+++ b/LSLib/Granny/Model/ColladaImporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Alphaleonis.Win32.Filesystem;
 using LSLib.Granny.GR2;
@@ -710,12 +711,20 @@ namespace LSLib.Granny.Model
                     influenceSum += weights[weightIndex];
                 }
 
+                byte total = 0;
+                float remainder = 0;
+
                 for (var i = 0; i < influenceCount; i++)
                 {
                     var jointIndex = influences[offset + jointInputIndex];
                     var weightIndex = influences[offset + weightInputIndex];
                     var joint = joints[jointIndex];
-                    var weight = weights[weightIndex] / influenceSum;
+
+                    float weightF = weights[weightIndex] / influenceSum * 255 + remainder;
+                    byte weight = (byte)Math.Round(weightF);
+                    remainder = weightF - weight;
+                    total += weight;
+
                     // Not all vertices are actually used in triangles, we may have unused verts in the
                     // source list (though this is rare) which won't show up in the consolidated vertex map.
                     if (mesh.OriginalToConsolidatedVertexIndexMap.TryGetValue(vertexIndex, out List<int> consolidatedIndices))
@@ -729,6 +738,8 @@ namespace LSLib.Granny.Model
 
                     offset += stride;
                 }
+
+                Debug.Assert(total == 0 || total == 255);
             }
 
             foreach (var vertex in mesh.PrimaryVertexData.Vertices)

--- a/LSLib/Granny/Model/Vertex.cs
+++ b/LSLib/Granny/Model/Vertex.cs
@@ -363,7 +363,13 @@ namespace LSLib.Granny.Model
             return MemberwiseClone() as Vertex;
         }
 
+        [Obsolete("Using this method may accidentally lead to a vertex having improperly normalized weights. Consider using AddInfluence(byte, byte) instead.")]
         public void AddInfluence(byte boneIndex, float weight)
+        {
+            AddInfluence(boneIndex, (byte)Math.Round(weight * 255));
+        }
+
+        public void AddInfluence(byte boneIndex, byte weight)
         {
             // Get the first zero vertex influence and update it with the new one
             for (var influence = 0; influence < 4; influence++)
@@ -372,7 +378,7 @@ namespace LSLib.Granny.Model
                 {
                     // BoneIndices refers to Mesh.BoneBindings[index], not Skeleton.Bones[index] !
                     BoneIndices[influence] = boneIndex;
-                    BoneWeights[influence] = (byte)(Math.Round(weight * 255));
+                    BoneWeights[influence] = weight;
                     break;
                 }
             }


### PR DESCRIPTION
This fixes an issue where the total weight for a given vertex was sometimes not equal to 255 due to rounding error. This caused weird artifacts in-game after modifying a model's weights that weren't visible in Blender nor exported Collada files.

Below is an example of this problem where I just subdivided the entire mesh to make it very obvious. Notice the jagged edges of the shoulders in the before shot:
| Before (v1.18.7) | After |
| ---------------- | ----- |
| ![before](https://github.com/Norbyte/lslib/assets/1349975/1ff85434-6ec1-4eef-8f73-807d2decbd4f) | ![after](https://github.com/Norbyte/lslib/assets/1349975/568989c0-627e-4cb2-be6c-f92ca73e4b39) |
