### PR TITLE
Fix exported animations causing BG3 and DOS2 DE to crash

### DIFF
--- a/LSLib/Granny/GR2/Format.cs
+++ b/LSLib/Granny/GR2/Format.cs
@@ -524,7 +524,7 @@ namespace LSLib.Granny.GR2
         TrackGroup = 1,
         Skeleton = 2,
         Mesh = 3,
-        CurveAndDiscardable = 4,
+        StructDefinitions = 4,
         FirstVertexData = 5,
         Invalid = 0xffffffff
     };

--- a/LSLib/Granny/GR2/Writer.cs
+++ b/LSLib/Granny/GR2/Writer.cs
@@ -802,7 +802,7 @@ namespace LSLib.Granny.GR2
 
                 foreach (var defn in Types.Values)
                 {
-                    Sections[(int)SectionType.CurveAndDiscardable].WriteStructDefinition(defn);
+                    Sections[(int)SectionType.StructDefinitions].WriteStructDefinition(defn);
                 }
 
                 // We need to do this again to flush strings written by WriteMemberDefinition()

--- a/LSLib/Granny/Model/Animation.cs
+++ b/LSLib/Granny/Model/Animation.cs
@@ -27,7 +27,7 @@ namespace LSLib.Granny.Model
 
     public class AnimationCurve
     {
-        [Serialization(Section = SectionType.CurveAndDiscardable, TypeSelector = typeof(AnimationCurveDataTypeSelector), Type = MemberType.VariantReference, MinVersion = 0x80000011)]
+        [Serialization(Section = SectionType.Main, TypeSelector = typeof(AnimationCurveDataTypeSelector), Type = MemberType.VariantReference, MinVersion = 0x80000011)]
         public AnimationCurveData CurveData;
         [Serialization(MaxVersion = 0x80000010)]
         public Int32 Degree;


### PR DESCRIPTION
Fixes #156. I explained how I got to this solution in the issue but TL;DR is that BG3 and DOS2 DE expect animation curve data to be serialized into the main section rather than the 5th section of the file. Luckily DOS and DOS2 don't seem to care where it is so we can get away with always writing curve data to the main section regardless of the game.