### PR TITLE
Tiny bodge around Ztsd stream not supporting position

### DIFF
--- a/LSLib/LS/Story/Database.cs
+++ b/LSLib/LS/Story/Database.cs
@@ -203,7 +203,10 @@ public class Database : OsirisSerializable
         Parameters = new ParameterList();
         Parameters.Read(reader);
 
-        FactsPosition = reader.BaseStream.Position;
+        if (reader.BaseStream.CanSeek)
+        {
+            FactsPosition = reader.BaseStream.Position;
+        }
         Facts = new FactCollection(this, reader.Story);
         reader.ReadList<Fact>(Facts);
     }


### PR DESCRIPTION
Hi there!

Please feel free to reject this but it seems with the new Ztsd compression there's no support for positions, but it also seems that the position value when using the steam is not really used since the other log is sound save for debug messages.

It's a one second fix but it seems to run okay to load save files locally on my machine with latest master

Also thanks for doing this work!