### PR TITLE
added excludeHidden variable to AddFilesFromPath and CreatePackage to…

### DIFF
--- a/LSLib/LS/PackageCommon.cs
+++ b/LSLib/LS/PackageCommon.cs
@@ -191,7 +191,6 @@ public class Packager
             {
                 return true;
             }
-            return false;
         }
         else if (!build.ExcludeHidden)
         {

--- a/LSLib/LS/PackageCommon.cs
+++ b/LSLib/LS/PackageCommon.cs
@@ -120,10 +120,8 @@ public class PackageBuildData
     public bool Hash = false;
     public List<PackageBuildInputFile> Files = [];
     
-    public bool ExcludeHidden
-    { get; set; } = true;
-    public byte Priority
-    { get; set; } = 0;
+    public bool ExcludeHidden { get; set; } = true;
+    public byte Priority { get; set; } = 0;
 
 }
 
@@ -180,25 +178,16 @@ public class Packager
         UncompressPackage(package, outputPath, filter);
     }
 
-
     public static bool ShouldInclude(string file, PackageBuildData build)
     {
-        string[] fileElements = file.Split(Path.DirectorySeparatorChar);
-
         if (build.ExcludeHidden) 
         {
-            if (!Array.Exists(fileElements, element => element.StartsWith(".")))
-            {
-                return true;
-            }
-        }
-        else if (!build.ExcludeHidden)
-        {
-            return true;
+            var fileElements = file.Split(Path.DirectorySeparatorChar);
+
+            return Array.Exists(fileElements, element => element.StartsWith('.'));
         }
         return false;
     }
-
 
     private static void AddFilesFromPath(PackageBuildData build, string path)
     {


### PR DESCRIPTION
exposes a new option and packing priority in lslib.dll

- lets lslib.dll users optionally exclude files and folders that start with '.'
- exposes packing priority to allow adjustment outside of lslib