### PR TITLE
Added .packignore support to exclude files from PAKs

### DIFF
--- a/LSLib/LS/PackIgnore.cs
+++ b/LSLib/LS/PackIgnore.cs
@@ -32,7 +32,6 @@ public class PackIgnore
 
     public bool IsIgnored(string relativePath)
     {
-
         string normalizedPath = relativePath.Replace("\\", "/");
 
         foreach (var pattern in ignorePatterns)
@@ -57,7 +56,7 @@ public class PackIgnore
         }
 
         return new Regex("^" + pattern + "$", RegexOptions.IgnoreCase);
-    }
+    }    
 }
 
 

--- a/LSLib/LS/PackIgnore.cs
+++ b/LSLib/LS/PackIgnore.cs
@@ -58,6 +58,3 @@ public class PackIgnore
         return new Regex("^" + pattern + "$", RegexOptions.IgnoreCase);
     }    
 }
-
-
-

--- a/LSLib/LS/PackIgnore.cs
+++ b/LSLib/LS/PackIgnore.cs
@@ -1,0 +1,64 @@
+﻿namespace LSLib.LS;
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+public class PackIgnore
+{
+    private readonly List<Regex> ignorePatterns = new List<Regex>();
+
+    public PackIgnore(string directory)
+    {
+        LoadIgnoreList(directory);
+    }
+
+    private void LoadIgnoreList(string directory)
+    {
+        string ignoreFilePath = Path.Combine(directory, ".packignore");
+
+        if (File.Exists(ignoreFilePath))
+        {
+            foreach (var line in File.ReadAllLines(ignoreFilePath))
+            {
+                string pattern = line.Trim();
+                if (string.IsNullOrEmpty(pattern) || pattern.StartsWith("#"))
+                    continue; // Ignore empty lines and comments
+
+                ignorePatterns.Add(WildcardToRegex(pattern));
+            }
+        }
+    }
+
+    public bool IsIgnored(string relativePath)
+    {
+
+        string normalizedPath = relativePath.Replace("\\", "/");
+
+        foreach (var pattern in ignorePatterns)
+        {
+            if (pattern.IsMatch(normalizedPath))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static Regex WildcardToRegex(string wildcard)
+    {
+        string pattern = Regex.Escape(wildcard)
+        .Replace(@"\*", ".*")    // * = any characters
+        .Replace(@"\?", ".");    // ? = any single character
+
+        // If it ends with '/', treat it as a directory match (match everything inside)
+        if (wildcard.EndsWith("/"))
+        {
+            pattern = pattern.TrimEnd('/') + @"/.*";
+        }
+
+        return new Regex("^" + pattern + "$", RegexOptions.IgnoreCase);
+    }
+}
+
+
+


### PR DESCRIPTION
# Add `.packignore` support to exclude files from PAK archives

This PR introduces support for a `.packignore` file, allowing modders to exclude specific files and directories from being packed into `.PAK` archives. This prevents unwanted files, such as source control folders, temporary logs, or build artifacts, from being included in the final package.

## Why This Feature is Needed
Currently, LSLib includes all files within a directory when creating a `.PAK`, which can lead to temporary build files and other unnecessary files being packed. Until now, modders had to manually remove these files before packaging. This PR provides a clean solution by allowing modders to define exclusions in a `.packignore` file.

## How It Works
The `.packignore` file is placed in the mod directory and follows a similar syntax to `.gitignore`, supporting:
- **Specific files** (`debug.log`, `config.json`)
- **Folders** (`bin/`, `obj/`, `.git/`)
- **Wildcards** (`*.log`, `*.tmp`)

### Example `.packignore` file:
```
.git/
.vs/
*.bak
*.tmp
.*
```