### PR TITLE
Fix Culture settings when serializing floats and doubles

### DIFF
--- a/LSLib/LS/Matrix.cs
+++ b/LSLib/LS/Matrix.cs
@@ -37,6 +37,7 @@ using System.Text.RegularExpressions;
 
 namespace LSLib.LS;
 
+using System.Globalization;
 
 public class Matrix
 {
@@ -257,7 +258,7 @@ public class Matrix
             for (int i = 0; i < rows.Length; i++)
             {
                 nums = rows[i].Split(' ');
-                for (int j = 0; j < nums.Length; j++) matrix[i, j] = double.Parse(nums[j]);
+                for (int j = 0; j < nums.Length; j++) matrix[i, j] = double.Parse(nums[j], CultureInfo.InvariantCulture);
             }
         }
         catch (FormatException) { throw new MException("Wrong input format!"); }

--- a/LSLib/LS/NodeAttribute.cs
+++ b/LSLib/LS/NodeAttribute.cs
@@ -4,6 +4,8 @@ using System.Linq;
 
 namespace LSLib.LS;
 
+using System.Globalization;
+
 public class TranslatedString
 {
     public UInt16 Version = 0;
@@ -243,12 +245,12 @@ public class NodeAttribute(AttributeType type)
             case AttributeType.IVec2:
             case AttributeType.IVec3:
             case AttributeType.IVec4:
-                return String.Join(" ", new List<int>((int[])value).ConvertAll(i => i.ToString()).ToArray());
+                return String.Join(" ", new List<int>((int[])value).ConvertAll(i => i.ToString(CultureInfo.InvariantCulture)).ToArray());
 
             case AttributeType.Vec2:
             case AttributeType.Vec3:
             case AttributeType.Vec4:
-                return String.Join(" ", new List<float>((float[])value).ConvertAll(i => i.ToString()).ToArray());
+                return String.Join(" ", new List<float>((float[])value).ConvertAll(i => i.ToString(CultureInfo.InvariantCulture)).ToArray());
 
             case AttributeType.UUID:
                 if (settings.ByteSwapGuids)
@@ -259,6 +261,12 @@ public class NodeAttribute(AttributeType type)
                 {
                     return value.ToString();
                 }
+
+            case AttributeType.Float:
+                return ((float) value).ToString(CultureInfo.InvariantCulture);
+
+            case AttributeType.Double:
+                return ((double) value).ToString(CultureInfo.InvariantCulture);
 
             default:
                 return value.ToString();

--- a/LSLib/LS/Resources/LSJ/LSJReader.cs
+++ b/LSLib/LS/Resources/LSJ/LSJReader.cs
@@ -2,6 +2,8 @@
 
 namespace LSLib.LS;
 
+using System.Globalization;
+
 public class LSJReader(Stream stream) : IDisposable
 {
     private readonly Stream stream = stream;
@@ -16,6 +18,7 @@ public class LSJReader(Stream stream) : IDisposable
     {
         var settings = new JsonSerializerSettings();
         settings.Converters.Add(new LSJResourceConverter(SerializationSettings));
+        settings.Culture = CultureInfo.InvariantCulture;
         var serializer = JsonSerializer.Create(settings);
 
         using var streamReader = new StreamReader(stream);

--- a/LSLib/LS/Resources/LSJ/LSJResourceConverter.cs
+++ b/LSLib/LS/Resources/LSJ/LSJResourceConverter.cs
@@ -4,6 +4,8 @@ using System.Numerics;
 
 namespace LSLib.LS;
 
+using System.Globalization;
+
 public class LSJResourceConverter(NodeSerializationSettings settings) : JsonConverter
 {
     private LSMetadata Metadata;
@@ -200,11 +202,11 @@ public class LSJResourceConverter(NodeSerializationSettings settings) : JsonConv
                             break;
 
                         case AttributeType.Float:
-                            attribute.Value = Convert.ToSingle(reader.Value);
+                            attribute.Value = Convert.ToSingle(reader.Value, CultureInfo.InvariantCulture);
                             break;
 
                         case AttributeType.Double:
-                            attribute.Value = Convert.ToDouble(reader.Value);
+                            attribute.Value = Convert.ToDouble(reader.Value, CultureInfo.InvariantCulture);
                             break;
 
                         case AttributeType.Bool:
@@ -304,7 +306,7 @@ public class LSJResourceConverter(NodeSerializationSettings settings) : JsonConv
 
                                 float[] vec = new float[length];
                                 for (int i = 0; i < length; i++)
-                                    vec[i] = float.Parse(nums[i]);
+                                    vec[i] = float.Parse(nums[i], CultureInfo.InvariantCulture);
 
                                 attribute.Value = vec;
                                 break;

--- a/LSLib/LS/Resources/LSJ/LSJWriter.cs
+++ b/LSLib/LS/Resources/LSJ/LSJWriter.cs
@@ -2,6 +2,8 @@
 
 namespace LSLib.LS;
 
+using System.Globalization;
+
 public class LSJWriter(Stream stream)
 {
     private readonly Stream stream = stream;
@@ -21,6 +23,7 @@ public class LSJWriter(Stream stream)
         using var writer = new JsonTextWriter(streamWriter);
         writer.IndentChar = '\t';
         writer.Indentation = 1;
+        writer.Culture = CultureInfo.InvariantCulture;
         serializer.Serialize(writer, rsrc);
     }
 }

--- a/LSLib/LS/Resources/LSX/LSXReader.cs
+++ b/LSLib/LS/Resources/LSX/LSXReader.cs
@@ -4,6 +4,8 @@ using System.Xml;
 
 namespace LSLib.LS;
 
+using System.Globalization;
+
 public class LSXReader(Stream stream) : IDisposable
 {
     private Stream stream = stream;
@@ -215,27 +217,27 @@ public class LSXReader(Stream stream) : IDisposable
             case "float2":
                 {
                     var val = (float[])LastAttribute.Value;
-                    val[ValueOffset++] = Single.Parse(reader["x"]);
-                    val[ValueOffset++] = Single.Parse(reader["y"]);
+                    val[ValueOffset++] = Single.Parse(reader["x"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["y"], CultureInfo.InvariantCulture);
                     break;
                 }
 
             case "float3":
                 {
                     var val = (float[])LastAttribute.Value;
-                    val[ValueOffset++] = Single.Parse(reader["x"]);
-                    val[ValueOffset++] = Single.Parse(reader["y"]);
-                    val[ValueOffset++] = Single.Parse(reader["z"]);
+                    val[ValueOffset++] = Single.Parse(reader["x"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["y"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["z"], CultureInfo.InvariantCulture);
                     break;
                 }
 
             case "float4":
                 {
                     var val = (float[])LastAttribute.Value;
-                    val[ValueOffset++] = Single.Parse(reader["x"]);
-                    val[ValueOffset++] = Single.Parse(reader["y"]);
-                    val[ValueOffset++] = Single.Parse(reader["z"]);
-                    val[ValueOffset++] = Single.Parse(reader["w"]);
+                    val[ValueOffset++] = Single.Parse(reader["x"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["y"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["z"], CultureInfo.InvariantCulture);
+                    val[ValueOffset++] = Single.Parse(reader["w"], CultureInfo.InvariantCulture);
                     break;
                 }
 

--- a/LSLib/LS/Story/Database.cs
+++ b/LSLib/LS/Story/Database.cs
@@ -2,6 +2,8 @@
 
 namespace LSLib.LS.Story;
 
+using System.Globalization;
+
 public class Fact : OsirisSerializable
 {
     public List<Value> Columns;
@@ -121,7 +123,7 @@ internal class FactPropertyDescriptor : PropertyDescriptor
 
             case Value.Type.Float:
                 {
-                    if (value is String) column.FloatValue = Single.Parse((String)value);
+                    if (value is String) column.FloatValue = Single.Parse((String)value, CultureInfo.InvariantCulture);
                     else if (value is Single) column.FloatValue = (Single)value;
                     else throw new ArgumentException("Invalid float value");
                     break;


### PR DESCRIPTION
Use CultureInfo.InvariantCulture when serializing floats and doubles to make sure that the period is the decimal separator independent of the running user's UI culture.

Fixes #240.