### PR TITLE
Fix null pointer crash when exporting some Granny assets

### DIFF
--- a/LSLib/Granny/Model/GLTFExporter.cs
+++ b/LSLib/Granny/Model/GLTFExporter.cs
@@ -262,10 +262,10 @@ public class GLTFExporter
         ext.Cloth01 = user.ClothFlags.HasClothFlag01();
         ext.Cloth02 = user.ClothFlags.HasClothFlag02();
         ext.Cloth04 = user.ClothFlags.HasClothFlag04();
-        ext.Impostor = user.IsImpostor[0]  == 1;
+        ext.Impostor = user.IsImpostor != null && user.IsImpostor.Length > 0 && user.IsImpostor[0] == 1;
         ext.ExportOrder = mesh.ExportOrder;
-        ext.LOD = (user.Lod[0] >= 0) ? user.Lod[0] : 0;
-        ext.LODDistance = (user.LodDistance[0] < 100000000.0f) ? user.LodDistance[0] : 0.0f;
+        ext.LOD = (user.Lod != null && user.Lod.Length > 0 && user.Lod[0] >= 0) ? user.Lod[0] : 0;
+        ext.LODDistance = (user.LodDistance != null && user.LodDistance.Length > 0 && user.LodDistance[0] < 100000000.0f) ? user.LodDistance[0] : 0.0f;
         if (!mesh.IsSkinned() && mesh.BoneBindings != null && mesh.BoneBindings.Count == 1 && skeleton != null && !skeleton.IsDummy)
         {
             ext.ParentBone = mesh.BoneBindings[0].BoneName;


### PR DESCRIPTION
Converting some DOS2:DE assets from Granny -> GLTF will fail due to some user mesh properties not being checked for nulls. 

Tested with asset: `Orcs_Female_A.GR2` from `Shared.pak` (Dos2:DE)

*NOTE*: This fixes the issue, and I am able to convert the models, BUT I am not sure this fix the right way. Maybe the actual issue is that these are null in the first place. I do not know the application enough to know.